### PR TITLE
Fix mkdns IPv6 host overrides (use AAAA record type)

### DIFF
--- a/opnsense_mcp/tools/mkdns.py
+++ b/opnsense_mcp/tools/mkdns.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any
 
-from opnsense_mcp.utils.api import OPNsenseClient
+from opnsense_mcp.utils.api import OPNsenseClient, _record_type_for_server
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +80,14 @@ class MkdnsTool:
             }
 
         try:
+            record_type = _record_type_for_server(server)
+        except ValueError:
+            return {
+                "status": "error",
+                "error": f"Invalid IP address for server: {server}",
+            }
+
+        try:
             result = await self.client.add_host_override(
                 hostname=hostname,
                 domain=domain,
@@ -102,6 +110,7 @@ class MkdnsTool:
                 "hostname": hostname,
                 "domain": domain,
                 "server": server,
+                "rr": record_type,
                 "applied": True,
                 "status": "success",
             }

--- a/opnsense_mcp/utils/api.py
+++ b/opnsense_mcp/utils/api.py
@@ -23,6 +23,12 @@ logger = logging.getLogger(__name__)
 _MAC_RE = re.compile(r"^[0-9a-f]{2}([:-][0-9a-f]{2}){5}$", re.IGNORECASE)
 
 
+def _record_type_for_server(server: str) -> str:
+    """Return Unbound host-override record type (A or AAAA) for an IP address."""
+    addr = ipaddress.ip_address(server.strip())
+    return "AAAA" if addr.version == 6 else "A"
+
+
 def _reverse_name_matches_query(reverse_name: str, query: str) -> bool:
     """Return True when PTR reverse name confirms a hostname query."""
     q = query.lower().strip(".")
@@ -1114,8 +1120,10 @@ class OPNsenseClient:
         server: str,
         description: str = "",
         enabled: bool = True,
+        rr: str | None = None,
     ) -> dict[str, Any]:
         """Add a DNS host override to Unbound."""
+        record_type = rr if rr is not None else _record_type_for_server(server)
         return await self._make_request(
             "POST",
             ENDPOINTS["unbound"]["add"],
@@ -1124,7 +1132,7 @@ class OPNsenseClient:
                     "enabled": "1" if enabled else "0",
                     "hostname": hostname,
                     "domain": domain,
-                    "rr": "A",
+                    "rr": record_type,
                     "server": server,
                     "description": description,
                 }

--- a/tests/test_additional_tools.py
+++ b/tests/test_additional_tools.py
@@ -69,6 +69,7 @@ async def test_mkdns_and_rmdns_success_and_error_paths() -> None:
     )
     assert mkdns_result["status"] == "success"
     assert mkdns_result["uuid"] == "abc-123"
+    assert mkdns_result["rr"] == "A"
 
     rmdns = RmdnsTool(client)
     client.del_host_override.return_value = {"result": "deleted"}

--- a/tests/test_dns_host_override.py
+++ b/tests/test_dns_host_override.py
@@ -1,0 +1,110 @@
+"""Tests for Unbound DNS host override record type selection."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from opnsense_mcp.tools.mkdns import MkdnsTool
+from opnsense_mcp.utils.api import OPNsenseClient, _record_type_for_server
+
+
+@pytest.mark.parametrize(
+    ("server", "expected_rr"),
+    [
+        ("10.0.2.2", "A"),
+        ("192.168.1.1", "A"),
+        ("2601:441:8483:b501::5", "AAAA"),
+        ("2001:db8::1", "AAAA"),
+    ],
+)
+def test_record_type_for_server(server: str, expected_rr: str) -> None:
+    assert _record_type_for_server(server) == expected_rr
+
+
+def test_record_type_for_server_rejects_invalid_ip() -> None:
+    with pytest.raises(ValueError):
+        _record_type_for_server("not-an-ip")
+
+
+@pytest.mark.asyncio
+async def test_add_host_override_posts_ipv6_as_aaaa() -> None:
+    config = {
+        "firewall_host": "192.0.2.1",
+        "api_key": "k",
+        "api_secret": "s",
+    }
+    captured: dict = {}
+
+    async def fake_make_request(
+        method: str,
+        endpoint: str,
+        **kwargs: object,
+    ) -> dict:
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        captured["json"] = kwargs.get("json")
+        return {"uuid": "test-uuid-1"}
+
+    with (
+        patch.object(OPNsenseClient, "_detect_endpoint", return_value=None),
+        patch("opnsense_mcp.utils.api.requests.Session") as sess_cls,
+    ):
+        sess_cls.return_value = MagicMock()
+        client = OPNsenseClient(config)
+        client._make_request = AsyncMock(side_effect=fake_make_request)
+
+        await client.add_host_override(
+            hostname="pi5",
+            domain="example.com",
+            server="2601:441:8483:b501::5",
+        )
+
+    assert captured["method"] == "POST"
+    assert captured["endpoint"] == "/api/unbound/settings/addHostOverride"
+    host = captured["json"]["host"]
+    assert host["rr"] == "AAAA"
+    assert host["server"] == "2601:441:8483:b501::5"
+
+
+@pytest.mark.asyncio
+async def test_mkdns_returns_aaaa_for_ipv6_server() -> None:
+    client = AsyncMock()
+    client.add_host_override.return_value = {"uuid": "abc-123"}
+    client.reconfigure_unbound.return_value = {"status": "ok"}
+    mkdns = MkdnsTool(client)
+
+    result = await mkdns.execute(
+        {
+            "hostname": "pi5",
+            "domain": "example.com",
+            "server": "2601:441:8483:b501::5",
+        }
+    )
+
+    assert result["status"] == "success"
+    assert result["rr"] == "AAAA"
+    client.add_host_override.assert_awaited_once_with(
+        hostname="pi5",
+        domain="example.com",
+        server="2601:441:8483:b501::5",
+        description="",
+        enabled=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mkdns_rejects_invalid_server_ip() -> None:
+    client = AsyncMock()
+    mkdns = MkdnsTool(client)
+
+    result = await mkdns.execute(
+        {
+            "hostname": "pi5",
+            "domain": "example.com",
+            "server": "not-an-ip",
+        }
+    )
+
+    assert result["status"] == "error"
+    assert "Invalid IP address" in result["error"]
+    client.add_host_override.assert_not_called()


### PR DESCRIPTION
Fixes #9

## Summary

- Auto-select Unbound record type (`A` vs `AAAA`) from the `server` IP using `ipaddress`
- Return `rr` in successful `mkdns` responses so callers can verify what was created
- Reject invalid `server` values with a clear error before hitting the OPNsense API
- Expose MCP build metadata (`git_commit`, `git_ref`, `build_time`) via `system` tool and MCP `initialize` `serverInfo` for post-deploy verification
- Embed build metadata in container images at `podman build` time (`deploy/Containerfile` + `deploy/install.sh`)

## Test plan

- [x] `uv run python -m pytest tests/test_dns_host_override.py tests/test_build_info.py -v`
- [x] `uv run python -m pytest tests/test_additional_tools.py::test_mkdns_and_rmdns_success_and_error_paths -v`
- [ ] Redeploy strongpod from this branch:
  ```bash
  sudo env OPNSENSE_MCP_REPO_URL='https://github.com/coreyhines/opnsense-mcp.git' \
    OPNSENSE_MCP_GIT_REF='fix/mkdns-ipv6-aaaa-record-type' \
    bash /opt/containerdata/opnsense-mcp/src/deploy/install.sh
  ```
- [ ] MCP `system` → confirm `mcp_server.git_commit` matches branch HEAD
- [ ] MCP `mkdns` with IPv6 `server` → response includes `"rr": "AAAA"`
- [ ] MCP `mkdns` with invalid `server` → clear validation error (no API call)