### PR TITLE
Expose MCP build metadata for deploy verification

### DIFF
--- a/deploy/Containerfile
+++ b/deploy/Containerfile
@@ -4,6 +4,10 @@
 
 FROM docker.io/library/python:3.12-slim-bookworm
 
+ARG GIT_COMMIT=unknown
+ARG GIT_REF=unknown
+ARG BUILD_TIME=unknown
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PYTHONIOENCODING=utf-8 \
@@ -21,6 +25,12 @@ COPY requirements.txt pyproject.toml README.md ./
 COPY opnsense_mcp ./opnsense_mcp
 COPY examples ./examples
 COPY main.py ./
+
+RUN printf '%s\n' \
+    "GIT_COMMIT = \"${GIT_COMMIT}\"" \
+    "GIT_REF = \"${GIT_REF}\"" \
+    "BUILD_TIME = \"${BUILD_TIME}\"" \
+    > /app/opnsense_mcp/_build_info_generated.py
 
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt && \

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -285,7 +285,17 @@ if [[ "$RUNTIME" == "podman" ]]; then
   write_opnsense_mcp_pod "${QUADLET_DIR}/${POD_QUADLET_FILE}" "${POD_NAME}"
   write_opnsense_mcp_quadlet "${QUADLET_DIR}/${MCP_QUADLET_BASENAME}.container" "${POD_SVC}" "${POD_QUADLET_FILE}"
   write_caddy_quadlet "${QUADLET_DIR}/${CADDY_QUADLET_BASENAME}.container" "${POD_SVC}" "${MCP_APP_SVC}" "${POD_QUADLET_FILE}"
-  "${RUNTIME}" build -f "${SRC_DIR}/deploy/Containerfile" -t "${IMAGE_REPO}:${IMAGE_TAG}" "${SRC_DIR}"
+  BUILD_GIT_COMMIT=$(
+    git -C "${SRC_DIR}" rev-parse --short=12 HEAD 2>/dev/null || echo unknown
+  )
+  BUILD_GIT_REF="${GIT_REF}"
+  BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  echo "Building image with git_commit=${BUILD_GIT_COMMIT} git_ref=${BUILD_GIT_REF} build_time=${BUILD_TIME}" >&2
+  "${RUNTIME}" build -f "${SRC_DIR}/deploy/Containerfile" -t "${IMAGE_REPO}:${IMAGE_TAG}" \
+    --build-arg "GIT_COMMIT=${BUILD_GIT_COMMIT}" \
+    --build-arg "GIT_REF=${BUILD_GIT_REF}" \
+    --build-arg "BUILD_TIME=${BUILD_TIME}" \
+    "${SRC_DIR}"
   systemctl daemon-reload
   _pod_load_state=$(systemctl show -p LoadState --value "${POD_SVC}" 2>/dev/null || echo "unknown")
   if [[ "${_pod_load_state}" != "loaded" ]]; then
@@ -314,7 +324,10 @@ else
     echo "docker not found in PATH" >&2
     exit 1
   fi
-  (cd "${SRC_DIR}" && docker compose -p opnsense-mcp -f deploy/docker-compose.yml up -d --build)
+  (cd "${SRC_DIR}" && docker compose -p opnsense-mcp -f deploy/docker-compose.yml up -d --build \
+    --build-arg "GIT_COMMIT=$(git -C "${SRC_DIR}" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)" \
+    --build-arg "GIT_REF=${GIT_REF}" \
+    --build-arg "BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)")
 fi
 
 echo "Install finished (${RUNTIME})." >&2

--- a/opnsense_mcp/_build_info_generated.py
+++ b/opnsense_mcp/_build_info_generated.py
@@ -1,0 +1,5 @@
+"""Build metadata overwritten during container image build (see deploy/Containerfile)."""
+
+GIT_COMMIT = "unknown"
+GIT_REF = "unknown"
+BUILD_TIME = "unknown"

--- a/opnsense_mcp/build_info.py
+++ b/opnsense_mcp/build_info.py
@@ -1,0 +1,77 @@
+"""OPNsense MCP server build and package metadata."""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404 — subprocess required for local git metadata fallback
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+from opnsense_mcp import _build_info_generated as _generated
+
+
+def _package_version() -> str:
+    try:
+        return version("opnsense-mcp")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _runtime_git_commit() -> str | None:
+    """Best-effort short HEAD for local/dev runs without embedded build metadata."""
+    repo_root = Path(__file__).resolve().parent.parent
+    if not (repo_root / ".git").is_dir():
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--short=12", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=True,
+        )  # nosec B603 B607 — hardcoded git command, no user input
+    except (OSError, subprocess.SubprocessError):
+        return None
+    commit = result.stdout.strip()
+    return commit or None
+
+
+def _runtime_git_ref() -> str | None:
+    repo_root = Path(__file__).resolve().parent.parent
+    if not (repo_root / ".git").is_dir():
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=True,
+        )  # nosec B603 B607 — hardcoded git command, no user input
+    except (OSError, subprocess.SubprocessError):
+        return None
+    ref = result.stdout.strip()
+    return ref or None
+
+
+def get_build_info() -> dict[str, str]:
+    """Return package and build metadata for the running MCP server."""
+    git_commit = _generated.GIT_COMMIT
+    git_ref = _generated.GIT_REF
+    build_time = _generated.BUILD_TIME
+
+    if git_commit == "unknown":
+        runtime_commit = _runtime_git_commit()
+        if runtime_commit:
+            git_commit = runtime_commit
+    if git_ref == "unknown":
+        runtime_ref = _runtime_git_ref()
+        if runtime_ref:
+            git_ref = runtime_ref
+
+    return {
+        "name": "opnsense-mcp",
+        "package_version": _package_version(),
+        "git_commit": git_commit,
+        "git_ref": git_ref,
+        "build_time": build_time,
+    }

--- a/opnsense_mcp/server.py
+++ b/opnsense_mcp/server.py
@@ -80,6 +80,7 @@ _ensure_runtime_deps()
 import asyncio
 import json
 
+from opnsense_mcp.build_info import get_build_info
 from opnsense_mcp.tools.aliases import AliasesTool
 from opnsense_mcp.tools.arp import ARPTool
 from opnsense_mcp.tools.dhcp import DHCPTool
@@ -214,12 +215,19 @@ async def handle_message(
         protocol_version = message.get("params", {}).get("protocolVersion")
         if not protocol_version or protocol_version == "undefined":
             protocol_version = "2024-11-05"
+        build_info = get_build_info()
         return {
             "jsonrpc": "2.0",
             "id": msg_id,
             "result": {
                 "protocolVersion": protocol_version,
-                "serverInfo": {"name": "opnsense-mcp", "version": "1.0.0"},
+                "serverInfo": {
+                    "name": build_info["name"],
+                    "version": build_info["package_version"],
+                    "git_commit": build_info["git_commit"],
+                    "git_ref": build_info["git_ref"],
+                    "build_time": build_info["build_time"],
+                },
                 "capabilities": {"tools": {"listChanged": False}},
             },
         }

--- a/opnsense_mcp/tools/system.py
+++ b/opnsense_mcp/tools/system.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from opnsense_mcp.build_info import get_build_info
 from opnsense_mcp.utils.api import OPNsenseClient
 
 logger = logging.getLogger(__name__)
@@ -76,7 +77,11 @@ class SystemTool:
             # Combine system info and health data
             combined_status = {**system_info, **health_data}
 
-            return {"status": "success", "system": combined_status}
+            return {
+                "status": "success",
+                "system": combined_status,
+                "mcp_server": get_build_info(),
+            }
 
         except Exception as e:
             logger.exception("Failed to get system status")

--- a/tests/test_build_info.py
+++ b/tests/test_build_info.py
@@ -1,0 +1,29 @@
+"""Tests for MCP server build metadata."""
+
+from opnsense_mcp import _build_info_generated as generated
+from opnsense_mcp.build_info import get_build_info
+
+
+def test_get_build_info_uses_embedded_metadata(monkeypatch) -> None:
+    monkeypatch.setattr(generated, "GIT_COMMIT", "abc123def456")
+    monkeypatch.setattr(generated, "GIT_REF", "main")
+    monkeypatch.setattr(generated, "BUILD_TIME", "2026-06-07T22:00:00Z")
+
+    info = get_build_info()
+
+    assert info["name"] == "opnsense-mcp"
+    assert info["git_commit"] == "abc123def456"
+    assert info["git_ref"] == "main"
+    assert info["build_time"] == "2026-06-07T22:00:00Z"
+    assert info["package_version"] != "unknown"
+
+
+def test_get_build_info_falls_back_to_runtime_git(monkeypatch) -> None:
+    monkeypatch.setattr(generated, "GIT_COMMIT", "unknown")
+    monkeypatch.setattr(generated, "GIT_REF", "unknown")
+    monkeypatch.setattr(generated, "BUILD_TIME", "unknown")
+
+    info = get_build_info()
+
+    assert len(info["git_commit"]) >= 7
+    assert info["git_ref"] != "unknown"


### PR DESCRIPTION
## Summary

- Embed `git_commit`, `git_ref`, and `build_time` in container images at build time (`deploy/Containerfile`, `deploy/install.sh`)
- Return build metadata from the `system` tool as `mcp_server` and in MCP `initialize` `serverInfo`
- Add unit tests for embedded and runtime git fallback metadata
- Bandit `nosec` annotations on dev-only git subprocess helpers (matches `system.py` pattern)

Follow-up to #10 (mkdns IPv6/AAAA fix — already merged).

## Test plan

- [x] `uv run python -m pytest tests/test_build_info.py tests/test_bandit.py -v`
- [x] `uv run bandit -r opnsense_mcp/ -c pyproject.toml`
- [x] Live MCP `system` → `mcp_server.git_commit` matches deployed branch HEAD
- [ ] After merge: redeploy strongpod from `main` and confirm `mcp_server` is populated


Made with [Cursor](https://cursor.com)