### PR TITLE
Add flush_dns MCP tool for Unbound cache invalidation

### DIFF
--- a/opnsense_mcp/server.py
+++ b/opnsense_mcp/server.py
@@ -87,6 +87,7 @@ from opnsense_mcp.tools.dhcp import DHCPTool
 from opnsense_mcp.tools.dhcp_lease_delete import DHCPLeaseDeleteTool
 from opnsense_mcp.tools.dns import DNSTool
 from opnsense_mcp.tools.firewall_logs import FirewallLogsTool
+from opnsense_mcp.tools.flush_dns import FlushDnsTool
 from opnsense_mcp.tools.fw_rules import FwRulesTool
 from opnsense_mcp.tools.gateway_status import GatewayStatusTool
 from opnsense_mcp.tools.interface_list import InterfaceListTool
@@ -201,6 +202,7 @@ async def handle_message(
     dns_tool: DNSTool,
     mkdns_tool: MkdnsTool,
     rmdns_tool: RmdnsTool,
+    flush_dns_tool: FlushDnsTool,
     toggle_fw_rule_tool: ToggleFwRuleTool,
     set_fw_rule_tool: SetFwRuleTool,
     aliases_tool: AliasesTool,
@@ -643,6 +645,35 @@ async def handle_message(
                 },
             },
             {
+                "name": "flush_dns",
+                "description": (
+                    "Flush Unbound DNS cache for a hostname or restart Unbound "
+                    "to clear all cached answers"
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "hostname": {
+                            "type": "string",
+                            "description": (
+                                "FQDN to flush (e.g. headroom.freeblizz.com); "
+                                "required when mode=name"
+                            ),
+                            "optional": True,
+                        },
+                        "mode": {
+                            "type": "string",
+                            "description": (
+                                "name (default): unbound-control flush one host; "
+                                "restart: API restart clears full cache"
+                            ),
+                            "optional": True,
+                        },
+                    },
+                    "required": [],
+                },
+            },
+            {
                 "name": "toggle_fw_rule",
                 "description": "Enable or disable a firewall rule",
                 "inputSchema": {
@@ -927,6 +958,13 @@ async def handle_message(
                 "id": msg_id,
                 "result": {"content": [{"type": "text", "text": str(result)}]},
             }
+        if tool_name == "flush_dns":
+            result = await flush_dns_tool.execute(arguments)
+            return {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {"content": [{"type": "text", "text": str(result)}]},
+            }
         if tool_name == "toggle_fw_rule":
             result = await toggle_fw_rule_tool.execute(arguments)
             return {
@@ -1010,6 +1048,7 @@ def main() -> None:
     dns_tool = DNSTool(client)
     mkdns_tool = MkdnsTool(client)
     rmdns_tool = RmdnsTool(client)
+    flush_dns_tool = FlushDnsTool(client)
     toggle_fw_rule_tool = ToggleFwRuleTool(client)
     set_fw_rule_tool = SetFwRuleTool(client)
     aliases_tool = AliasesTool(client)
@@ -1073,6 +1112,7 @@ def main() -> None:
                     dns_tool,
                     mkdns_tool,
                     rmdns_tool,
+                    flush_dns_tool,
                     toggle_fw_rule_tool,
                     set_fw_rule_tool,
                     aliases_tool,

--- a/opnsense_mcp/tools/flush_dns.py
+++ b/opnsense_mcp/tools/flush_dns.py
@@ -1,0 +1,122 @@
+"""Unbound DNS cache flush tool for OPNsense."""
+
+from __future__ import annotations
+
+import logging
+import re
+import shlex
+from typing import TYPE_CHECKING, Any
+
+from opnsense_mcp.utils.ssh_client import OPNsenseSSHClient
+
+if TYPE_CHECKING:
+    from opnsense_mcp.utils.api import OPNsenseClient
+
+logger = logging.getLogger(__name__)
+
+_HOSTNAME_RE = re.compile(
+    r"^(?=.{1,253}$)([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+"
+    r"[a-zA-Z]{2,63}$"
+)
+
+_UNBOUND_CONTROL = "/usr/local/sbin/unbound-control"
+
+
+class FlushDnsTool:
+    """Flush Unbound DNS cache entries after host override changes."""
+
+    name = "flush_dns"
+    description = (
+        "Flush Unbound DNS cache for a hostname (SSH unbound-control) or restart "
+        "Unbound (API) to clear all cached answers"
+    )
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "hostname": {
+                "type": "string",
+                "description": (
+                    "FQDN to flush from cache (e.g. headroom.freeblizz.com). "
+                    "Required when mode=name."
+                ),
+                "optional": True,
+            },
+            "mode": {
+                "type": "string",
+                "description": (
+                    "name: flush one hostname via unbound-control (default); "
+                    "restart: restart Unbound via API (clears full cache)"
+                ),
+                "optional": True,
+            },
+        },
+        "required": [],
+    }
+
+    def __init__(self, client: OPNsenseClient | None) -> None:
+        self.client = client
+        self._ssh = OPNsenseSSHClient(client)
+
+    def _validate_hostname(self, hostname: str) -> str | None:
+        host = hostname.strip().rstrip(".")
+        if not host or not _HOSTNAME_RE.match(host):
+            return None
+        return host
+
+    async def execute(self, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        if params is None:
+            params = {}
+
+        if not self.client:
+            return {"status": "error", "error": "No client available"}
+
+        mode = str(params.get("mode", "name")).strip().lower() or "name"
+        if mode not in {"name", "restart"}:
+            return {
+                "status": "error",
+                "error": "mode must be 'name' or 'restart'",
+            }
+
+        if mode == "restart":
+            try:
+                result = await self.client.restart_unbound()
+                return {
+                    "status": "success",
+                    "mode": "restart",
+                    "applied": True,
+                    "result": result,
+                }
+            except Exception as e:
+                logger.exception("Failed to restart Unbound")
+                return {"status": "error", "error": str(e), "mode": "restart"}
+
+        hostname = str(params.get("hostname", "")).strip()
+        validated = self._validate_hostname(hostname)
+        if not validated:
+            return {
+                "status": "error",
+                "error": "hostname must be a valid FQDN when mode=name",
+                "mode": "name",
+            }
+
+        command = f"{_UNBOUND_CONTROL} flush {shlex.quote(validated)}"
+        ssh_result = self._ssh.execute_command(command)
+        if ssh_result.get("success"):
+            return {
+                "status": "success",
+                "mode": "name",
+                "hostname": validated,
+                "applied": True,
+                "command": command,
+                "stdout": ssh_result.get("stdout", ""),
+            }
+
+        return {
+            "status": "error",
+            "mode": "name",
+            "hostname": validated,
+            "error": ssh_result.get("stderr") or "unbound-control flush failed",
+            "command": command,
+            "exit_code": ssh_result.get("exit_code"),
+            "hint": "Retry with mode=restart to clear full Unbound cache via API",
+        }

--- a/opnsense_mcp/utils/api.py
+++ b/opnsense_mcp/utils/api.py
@@ -69,6 +69,7 @@ ENDPOINTS = {
         "set": "/api/unbound/settings/setHostOverride",
         "delete": "/api/unbound/settings/delHostOverride",
         "reconfigure": "/api/unbound/service/reconfigure",
+        "restart": "/api/unbound/service/restart",
     },
     "alias": {
         "search": "/api/firewall/alias/searchItem",
@@ -1149,6 +1150,10 @@ class OPNsenseClient:
     async def reconfigure_unbound(self) -> dict[str, Any]:
         """Apply Unbound DNS configuration changes."""
         return await self._make_request("POST", ENDPOINTS["unbound"]["reconfigure"])
+
+    async def restart_unbound(self) -> dict[str, Any]:
+        """Restart Unbound (clears resolver cache; brief DNS interruption)."""
+        return await self._make_request("POST", ENDPOINTS["unbound"]["restart"])
 
     async def search_aliases(self, search: str = "") -> list[dict[str, Any]]:
         """List firewall aliases, optionally filtered."""

--- a/tests/test_additional_tools.py
+++ b/tests/test_additional_tools.py
@@ -7,6 +7,7 @@ import pytest
 
 from opnsense_mcp.tools.aliases import AliasesTool
 from opnsense_mcp.tools.dns import DNSTool
+from opnsense_mcp.tools.flush_dns import FlushDnsTool
 from opnsense_mcp.tools.gateway_status import GatewayStatusTool
 from opnsense_mcp.tools.get_logs import GetLogsTool
 from opnsense_mcp.tools.mkdns import MkdnsTool
@@ -83,6 +84,35 @@ async def test_mkdns_and_rmdns_success_and_error_paths() -> None:
     assert mkdns_error["status"] == "error"
     rmdns_error = await RmdnsTool(None).execute({"uuid": "abc-123"})
     assert rmdns_error["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_flush_dns_success_and_error_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = AsyncMock()
+    client.restart_unbound.return_value = {"status": "ok"}
+    tool = FlushDnsTool(client)
+
+    monkeypatch.setattr(
+        tool._ssh,
+        "execute_command",
+        lambda _cmd: {"success": True, "stdout": "ok", "stderr": "", "exit_code": 0},
+    )
+    name_result = await tool.execute({"hostname": "headroom.freeblizz.com"})
+    assert name_result["status"] == "success"
+    assert name_result["mode"] == "name"
+    assert name_result["hostname"] == "headroom.freeblizz.com"
+
+    restart_result = await tool.execute({"mode": "restart"})
+    assert restart_result["status"] == "success"
+    assert restart_result["mode"] == "restart"
+
+    invalid = await tool.execute({"mode": "name", "hostname": "not-a-host"})
+    assert invalid["status"] == "error"
+
+    no_client = await FlushDnsTool(None).execute({"hostname": "x.example.com"})
+    assert no_client["status"] == "error"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds `flush_dns` MCP tool to clear stale Unbound answers after host override changes
- `mode=name` (default): SSH `unbound-control flush <hostname>` for a single FQDN
- `mode=restart`: `POST /api/unbound/service/restart` to clear the full resolver cache
- Unit tests cover success paths, invalid hostname, and missing client errors

## Test plan
- [x] `uv run pytest tests/test_additional_tools.py::test_flush_dns_success_and_error_paths`
- [x] Full test suite passes locally (`uv run pytest tests/`)
- [ ] Live verification on OPNsense: flush a hostname after `mkdns` change
- [ ] Live verification: `mode=restart` when per-host flush is insufficient
- Pi-hole cache flush remains handled separately via Pi-hole MCP in the workflow


Made with [Cursor](https://cursor.com)