### PR TITLE
Add Gitleaks pre-commit hooks and CI secret scanning

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,29 @@
+---
+name: Secret scan
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+  security-events: write
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,6 +128,17 @@ ai-review:
     - if: '$CI_MERGE_REQUEST_IID'
       when: on_success
 
+gitleaks:
+  stage: scanning
+  image:
+    name: ghcr.io/gitleaks/gitleaks:v8.30.1
+    entrypoint: [""]
+  variables:
+    GIT_DEPTH: "0"
+  script:
+    - gitleaks detect --config .gitleaks.toml --redact --log-opts main --verbose
+  allow_failure: false
+
 # GitGuardian — secret scan of commits in CI (requires masked GITGUARDIAN_API_KEY in CI/CD variables).
 gitguardian_scan:
   stage: scanning

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,14 @@
+title = "opnsense-mcp"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Env var placeholders and gitleaks artifacts"
+paths = [
+  '''\.gitleaks-baseline\.json$''',
+  '''gitleaks-report\.json$''',
+]
+regexes = [
+  '''\$\{[A-Z][A-Z0-9_]+\}''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,9 @@
-# Minimal pre-commit configuration to avoid Python 3.13 compatibility issues
 repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+        args: [--config, .gitleaks.toml, --redact, --log-opts, main]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:


### PR DESCRIPTION
## Summary
- Cherry-picked `a89dd8e` from stale `fix/ci-glama-maintenance` onto current `main`
- Adds Gitleaks pre-commit hook with `.gitleaks.toml` config
- Adds GitHub Actions `secret-scan` workflow and GitLab CI `gitleaks` job

## Context
The original `fix/ci-glama-maintenance` branch was partially merged earlier (CI/pre-commit fixes). This is the remaining Gitleaks-only commit, rebased via cherry-pick onto `main` after `flush_dns` and related merges.

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run pytest tests/` (79 passed)
- [ ] Verify GitHub `secret-scan` workflow passes on this PR
- [ ] Verify GitLab `gitleaks` job passes (if MR mirrored)
- [ ] After merge: delete remote `fix/ci-glama-maintenance`


Made with [Cursor](https://cursor.com)