### PR TITLE
Add DHCP subnet DNS MCP tools for dnsmasq and Kea

### DIFF
--- a/opnsense_mcp/server.py
+++ b/opnsense_mcp/server.py
@@ -85,6 +85,10 @@ from opnsense_mcp.tools.aliases import AliasesTool
 from opnsense_mcp.tools.arp import ARPTool
 from opnsense_mcp.tools.dhcp import DHCPTool
 from opnsense_mcp.tools.dhcp_lease_delete import DHCPLeaseDeleteTool
+from opnsense_mcp.tools.dhcp_subnet_dns import (
+    ListDhcpSubnetDnsTool,
+    SetDhcpSubnetDnsTool,
+)
 from opnsense_mcp.tools.dns import DNSTool
 from opnsense_mcp.tools.firewall_logs import FirewallLogsTool
 from opnsense_mcp.tools.flush_dns import FlushDnsTool
@@ -191,6 +195,8 @@ async def handle_message(
     arp_tool: ARPTool,
     dhcp_tool: DHCPTool,
     dhcp_lease_delete_tool: DHCPLeaseDeleteTool,
+    list_dhcp_subnet_dns_tool: ListDhcpSubnetDnsTool,
+    set_dhcp_subnet_dns_tool: SetDhcpSubnetDnsTool,
     lldp_tool: LLDPTool,
     system_tool: SystemTool,
     fw_rules_tool: FwRulesTool,
@@ -333,6 +339,19 @@ async def handle_message(
                         {"required": ["mac"]},
                     ],
                 },
+            },
+            {
+                "name": "list_dhcp_subnet_dns",
+                "description": (
+                    "List DHCP-provided DNS servers for a subnet scope "
+                    "(dnsmasq or Kea backends)"
+                ),
+                "inputSchema": ListDhcpSubnetDnsTool.input_schema,
+            },
+            {
+                "name": "set_dhcp_subnet_dns",
+                "description": SetDhcpSubnetDnsTool.description,
+                "inputSchema": SetDhcpSubnetDnsTool.input_schema,
             },
             {
                 "name": "lldp",
@@ -831,6 +850,20 @@ async def handle_message(
                 "id": msg_id,
                 "result": {"content": [{"type": "text", "text": str(result)}]},
             }
+        if tool_name == "list_dhcp_subnet_dns":
+            result = await list_dhcp_subnet_dns_tool.execute(arguments)
+            return {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {"content": [{"type": "text", "text": str(result)}]},
+            }
+        if tool_name == "set_dhcp_subnet_dns":
+            result = await set_dhcp_subnet_dns_tool.execute(arguments)
+            return {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {"content": [{"type": "text", "text": str(result)}]},
+            }
         if tool_name == "get_logs":
             logs = await firewall_logs.get_logs(
                 limit=arguments.get("limit", 500),
@@ -1037,6 +1070,8 @@ def main() -> None:
     arp_tool = ARPTool(client)
     dhcp_tool = DHCPTool(client)
     dhcp_lease_delete_tool = DHCPLeaseDeleteTool(client)
+    list_dhcp_subnet_dns_tool = ListDhcpSubnetDnsTool(client)
+    set_dhcp_subnet_dns_tool = SetDhcpSubnetDnsTool(client)
     lldp_tool = LLDPTool(client)
     system_tool = SystemTool(client)
     fw_rules_tool = FwRulesTool(client)
@@ -1101,6 +1136,8 @@ def main() -> None:
                     arp_tool,
                     dhcp_tool,
                     dhcp_lease_delete_tool,
+                    list_dhcp_subnet_dns_tool,
+                    set_dhcp_subnet_dns_tool,
                     lldp_tool,
                     system_tool,
                     fw_rules_tool,

--- a/opnsense_mcp/tools/dhcp_subnet_dns.py
+++ b/opnsense_mcp/tools/dhcp_subnet_dns.py
@@ -1,0 +1,158 @@
+"""MCP tools for DHCP per-subnet DNS configuration."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from opnsense_mcp.utils.api import OPNsenseClient
+
+logger = logging.getLogger(__name__)
+
+_SCOPE_PROPERTIES = {
+    "subnet": {
+        "type": "string",
+        "description": "Subnet in CIDR notation (e.g. 10.0.2.0/24)",
+        "optional": True,
+    },
+    "interface": {
+        "type": "string",
+        "description": "Interface identifier or description (e.g. opt2, VLAN2wired)",
+        "optional": True,
+    },
+}
+
+
+class ListDhcpSubnetDnsTool:
+    """Read DHCP-provided DNS servers for a subnet scope."""
+
+    name = "list_dhcp_subnet_dns"
+    description = (
+        "List DHCP-provided DNS servers for a subnet scope (dnsmasq or Kea backends)"
+    )
+    input_schema = {
+        "type": "object",
+        "properties": _SCOPE_PROPERTIES,
+        "anyOf": [{"required": ["subnet"]}, {"required": ["interface"]}],
+    }
+
+    def __init__(self, client: OPNsenseClient | None) -> None:
+        """Initialize the list tool."""
+        self.client = client
+
+    async def execute(self, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """List scoped DHCP DNS servers for IPv4 and IPv6."""
+        if params is None:
+            params = {}
+        if not self.client:
+            return {"status": "error", "error": "No client available"}
+
+        subnet = str(params.get("subnet") or "").strip() or None
+        interface = str(params.get("interface") or "").strip() or None
+        if not subnet and not interface:
+            return {
+                "status": "error",
+                "error": "Provide subnet (CIDR) and/or interface",
+            }
+
+        try:
+            result = await self.client.list_dhcp_subnet_dns(
+                subnet=subnet,
+                interface=interface,
+            )
+            return {"status": "success", **result}
+        except Exception as exc:
+            logger.exception("Failed to list DHCP subnet DNS")
+            return {"status": "error", "error": str(exc)}
+
+
+class SetDhcpSubnetDnsTool:
+    """Update DHCP-provided DNS servers for one address family."""
+
+    name = "set_dhcp_subnet_dns"
+    description = (
+        "Update DHCP-provided DNS servers for one address family on a subnet scope "
+        "(dnsmasq or Kea backends). Single address updates slot 1 unless slot=2."
+    )
+    input_schema = {
+        "type": "object",
+        "properties": {
+            **_SCOPE_PROPERTIES,
+            "family": {
+                "type": "string",
+                "description": "Address family to update: ipv4 or ipv6",
+            },
+            "dns_server": {
+                "type": "string",
+                "description": "Single DNS server address",
+                "optional": True,
+            },
+            "dns_servers": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "One or two DNS server addresses",
+                "optional": True,
+            },
+            "slot": {
+                "type": "integer",
+                "description": "Optional slot index (1 or 2) for single-address updates",
+                "optional": True,
+            },
+        },
+        "required": ["family"],
+        "anyOf": [{"required": ["subnet"]}, {"required": ["interface"]}],
+    }
+
+    def __init__(self, client: OPNsenseClient | None) -> None:
+        """Initialize the set tool."""
+        self.client = client
+
+    async def execute(self, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Apply a slot-oriented DNS update for one family."""
+        if params is None:
+            params = {}
+        if not self.client:
+            return {"status": "error", "error": "No client available"}
+
+        subnet = str(params.get("subnet") or "").strip() or None
+        interface = str(params.get("interface") or "").strip() or None
+        family = str(params.get("family") or "").strip()
+        dns_server = str(params.get("dns_server") or "").strip() or None
+        raw_servers = params.get("dns_servers")
+        dns_servers: list[str] | None = None
+        if isinstance(raw_servers, list):
+            dns_servers = [str(item).strip() for item in raw_servers if str(item).strip()]
+        slot_raw = params.get("slot")
+        slot = int(slot_raw) if slot_raw is not None else None
+
+        if not subnet and not interface:
+            return {
+                "status": "error",
+                "error": "Provide subnet (CIDR) and/or interface",
+            }
+        if not family:
+            return {"status": "error", "error": "family is required (ipv4 or ipv6)"}
+        if not dns_server and not dns_servers:
+            return {
+                "status": "error",
+                "error": "Provide dns_server or dns_servers",
+            }
+        if dns_server and dns_servers:
+            return {
+                "status": "error",
+                "error": "Provide either dns_server or dns_servers, not both",
+            }
+
+        try:
+            return await self.client.set_dhcp_subnet_dns(
+                subnet=subnet,
+                interface=interface,
+                family=family,
+                dns_server=dns_server,
+                dns_servers=dns_servers,
+                slot=slot,
+            )
+        except Exception as exc:
+            logger.exception("Failed to set DHCP subnet DNS")
+            return {"status": "error", "error": str(exc)}

--- a/opnsense_mcp/utils/api.py
+++ b/opnsense_mcp/utils/api.py
@@ -16,7 +16,12 @@ from typing import Any
 import requests
 from urllib3.exceptions import InsecureRequestWarning
 
-from opnsense_mcp.utils.dhcp_provider import DHCPProvider, detect_dhcp_backend
+from opnsense_mcp.utils.dhcp_provider import (
+    DHCPProvider,
+    detect_dhcp_backend,
+    require_subnet_dns_provider,
+)
+from opnsense_mcp.utils.dhcp_subnet_dns import Family, merge_slot_update
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 logger = logging.getLogger(__name__)
@@ -842,6 +847,66 @@ class OPNsenseClient:
         if self._dhcp_provider is None:
             raise RuntimeError("DHCP provider not initialized")
         return await self._dhcp_provider.delete_v6_lease(ip)
+
+    async def list_dhcp_subnet_dns(
+        self,
+        *,
+        subnet: str | None = None,
+        interface: str | None = None,
+    ) -> dict[str, Any]:
+        """List DHCP-provided DNS servers for a subnet scope."""
+        await self._ensure_dhcp_provider()
+        if self._dhcp_provider is None:
+            raise RuntimeError("DHCP provider not initialized")
+        provider = require_subnet_dns_provider(self._dhcp_provider)
+        return await provider.list_subnet_dns(subnet=subnet, interface=interface)
+
+    async def set_dhcp_subnet_dns(
+        self,
+        *,
+        subnet: str | None = None,
+        interface: str | None = None,
+        family: str,
+        dns_server: str | None = None,
+        dns_servers: list[str] | None = None,
+        slot: int | None = None,
+    ) -> dict[str, Any]:
+        """Update DHCP-provided DNS servers for one address family."""
+        await self._ensure_dhcp_provider()
+        if self._dhcp_provider is None:
+            raise RuntimeError("DHCP provider not initialized")
+        provider = require_subnet_dns_provider(self._dhcp_provider)
+        normalized_family: Family
+        if family.strip().lower() in {"ipv4", "v4", "inet"}:
+            normalized_family = "ipv4"
+        elif family.strip().lower() in {"ipv6", "v6", "inet6"}:
+            normalized_family = "ipv6"
+        else:
+            msg = f"Invalid family {family!r}; expected ipv4 or ipv6"
+            raise ValueError(msg)
+
+        current = await provider.list_subnet_dns(subnet=subnet, interface=interface)
+        current_servers = (
+            current.get("ipv4", [])
+            if normalized_family == "ipv4"
+            else current.get("ipv6", [])
+        )
+        if not isinstance(current_servers, list):
+            current_servers = []
+
+        merged = merge_slot_update(
+            [str(item) for item in current_servers],
+            dns_server=dns_server,
+            dns_servers=dns_servers,
+            slot=slot,
+            family=normalized_family,
+        )
+        return await provider.set_subnet_dns(
+            subnet=subnet,
+            interface=interface,
+            family=normalized_family,
+            servers=merged,
+        )
 
     async def get_firewall_logs(
         self: "OPNsenseClient", limit: int = 100

--- a/opnsense_mcp/utils/dhcp_provider.py
+++ b/opnsense_mcp/utils/dhcp_provider.py
@@ -39,6 +39,22 @@ class DHCPProvider(Protocol):
         """Delete a DHCPv6 lease by IP address."""
 
 
+def provider_supports_subnet_dns(provider: DHCPProvider) -> bool:
+    """Return True when the detected provider supports subnet DNS tools."""
+    return bool(getattr(provider, "SUBNET_DNS_SUPPORTED", False))
+
+
+def require_subnet_dns_provider(provider: DHCPProvider) -> Any:
+    """Return provider when subnet DNS is supported, else raise ValueError."""
+    if not provider_supports_subnet_dns(provider):
+        backend = getattr(provider, "name", provider.__class__.__name__)
+        msg = (
+            f"Subnet DNS configuration is not supported for DHCP backend {backend!r}"
+        )
+        raise ValueError(msg)
+    return provider
+
+
 _BACKEND_PROBES: list[tuple[str, type[DHCPProvider]]] = [
     (KeaProvider.SERVICE_STATUS_ENDPOINT, KeaProvider),
     (DnsmasqProvider.SERVICE_STATUS_ENDPOINT, DnsmasqProvider),

--- a/opnsense_mcp/utils/dhcp_providers/dnsmasq.py
+++ b/opnsense_mcp/utils/dhcp_providers/dnsmasq.py
@@ -4,6 +4,17 @@ import logging
 from collections.abc import Callable, Coroutine
 from typing import Any
 
+from opnsense_mcp.utils.dhcp_scope import resolve_scope_from_selectors
+from opnsense_mcp.utils.dhcp_subnet_dns import (
+    DhcpScope,
+    Family,
+    SubnetDnsSnapshot,
+    extract_rows,
+    format_dns_server_list,
+    interface_matches,
+    parse_dns_server_list,
+)
+
 logger = logging.getLogger(__name__)
 
 MakeRequestFn = Callable[..., Coroutine[Any, Any, dict[str, Any] | list[Any]]]
@@ -15,6 +26,16 @@ class DnsmasqProvider:
     name = "dnsmasq"
     LEASE_ENDPOINT = "/api/dnsmasq/leases/search"
     SERVICE_STATUS_ENDPOINT = "/api/dnsmasq/service/status"
+    OPTIONS_SEARCH_ENDPOINT = "/api/dnsmasq/settings/search_option"
+    OPTION_GET_ENDPOINT = "/api/dnsmasq/settings/get_option"
+    OPTION_SET_ENDPOINT = "/api/dnsmasq/settings/set_option"
+    OPTION_ADD_ENDPOINT = "/api/dnsmasq/settings/add_option"
+    OPTION_DEL_ENDPOINT = "/api/dnsmasq/settings/del_option"
+    RANGES_SEARCH_ENDPOINT = "/api/dnsmasq/settings/search_range"
+    RECONFIGURE_ENDPOINT = "/api/dnsmasq/service/reconfigure"
+    WRITE_TIMEOUT_SECONDS = 30
+    RECONFIGURE_TIMEOUT_SECONDS = 60
+    SUBNET_DNS_SUPPORTED = True
 
     def __init__(self, make_request: MakeRequestFn) -> None:
         """Initialize provider with request function."""
@@ -109,4 +130,251 @@ class DnsmasqProvider:
             "status": "error",
             "error": "Lease deletion not supported by dnsmasq backend",
             "ip": ip,
+        }
+
+    async def resolve_subnet_scope(
+        self,
+        *,
+        subnet: str | None,
+        interface: str | None,
+    ) -> DhcpScope:
+        """Resolve a subnet/interface selector to a dnsmasq DHCP scope."""
+        return await resolve_scope_from_selectors(
+            self._request,
+            subnet=subnet,
+            interface=interface,
+            range_search_endpoint=self.RANGES_SEARCH_ENDPOINT,
+        )
+
+    async def _load_options(self) -> list[dict[str, Any]]:
+        """Load all dnsmasq DHCP option rows."""
+        response = await self._request("GET", self.OPTIONS_SEARCH_ENDPOINT)
+        return extract_rows(response)
+
+    def _option_matches_scope(
+        self,
+        row: dict[str, Any],
+        scope: DhcpScope,
+        family: Family,
+    ) -> bool:
+        """Return True when an option row matches scope and DNS family."""
+        row_interface = str(row.get("interface") or "").strip()
+        if not interface_matches(row_interface, scope.interface):
+            return False
+        if family == "ipv4":
+            return str(row.get("option") or "").strip() == "6"
+        return str(row.get("option6") or "").strip() == "23"
+
+    async def _find_option_row(
+        self,
+        scope: DhcpScope,
+        family: Family,
+    ) -> dict[str, Any] | None:
+        """Find the dnsmasq option row for scoped DNS servers."""
+        for row in await self._load_options():
+            if self._option_matches_scope(row, scope, family):
+                return row
+        return None
+
+    async def _flat_option_payload(
+        self,
+        row: dict[str, Any],
+        scope: DhcpScope,
+        family: Family,
+        value: str,
+    ) -> dict[str, Any]:
+        """Build a flat dnsmasq option payload accepted by set_option."""
+        payload: dict[str, Any] = {
+            "uuid": str(row.get("uuid") or ""),
+            "type": str(row.get("type") or "set"),
+            "interface": str(row.get("interface") or scope.interface),
+            "tag": str(row.get("tag") or ""),
+            "set_tag": str(row.get("set_tag") or ""),
+            "value": value,
+            "force": str(row.get("force") or "0"),
+            "description": str(row.get("description") or ""),
+        }
+        if family == "ipv4":
+            payload["option"] = "6"
+            payload["option6"] = ""
+        else:
+            payload["option6"] = "23"
+            payload["option"] = ""
+        return payload
+
+    async def _read_option_snapshot(
+        self,
+        scope: DhcpScope,
+        family: Family,
+    ) -> SubnetDnsSnapshot:
+        """Read current scoped DNS servers for one family."""
+        row = await self._find_option_row(scope, family)
+        if not row:
+            return SubnetDnsSnapshot(family=family, servers=[], backend_payload=None)
+        value = str(row.get("value") or "")
+        servers = parse_dns_server_list(value, family)
+        payload = await self._flat_option_payload(row, scope, family, value)
+        return SubnetDnsSnapshot(
+            family=family,
+            servers=servers,
+            backend_payload=payload,
+        )
+
+    async def list_subnet_dns(
+        self,
+        *,
+        subnet: str | None = None,
+        interface: str | None = None,
+    ) -> dict[str, Any]:
+        """Return scoped IPv4/IPv6 DNS servers from dnsmasq DHCP options."""
+        scope = await self.resolve_subnet_scope(subnet=subnet, interface=interface)
+        ipv4 = await self._read_option_snapshot(scope, "ipv4")
+        ipv6 = await self._read_option_snapshot(scope, "ipv6")
+        return {
+            "backend": self.name,
+            "scope": {
+                "interface": scope.interface,
+                "subnet": scope.subnet,
+                "description": scope.description,
+            },
+            "ipv4": ipv4.servers,
+            "ipv6": ipv6.servers,
+        }
+
+    async def _write_option_snapshot(
+        self,
+        scope: DhcpScope,
+        snapshot: SubnetDnsSnapshot,
+    ) -> None:
+        """Write one dnsmasq option snapshot for rollback or apply."""
+        family = snapshot.family
+        formatted = format_dns_server_list(snapshot.servers, family)
+        payload = snapshot.backend_payload
+
+        if payload and payload.get("uuid"):
+            uuid = str(payload["uuid"])
+            option_data = {
+                key: value
+                for key, value in payload.items()
+                if key != "uuid"
+            }
+            option_data["value"] = formatted
+            await self._request(
+                "POST",
+                f"{self.OPTION_SET_ENDPOINT}/{uuid}",
+                json={"option": option_data},
+                timeout=self.WRITE_TIMEOUT_SECONDS,
+            )
+            return
+
+        if not snapshot.servers:
+            return
+
+        new_option: dict[str, Any] = {
+            "type": "set",
+            "interface": scope.interface,
+            "value": formatted,
+            "force": "0",
+            "tag": "",
+            "set_tag": "",
+            "description": "",
+        }
+        if family == "ipv4":
+            new_option["option"] = "6"
+            new_option["option6"] = ""
+        else:
+            new_option["option6"] = "23"
+            new_option["option"] = ""
+        await self._request(
+            "POST",
+            self.OPTION_ADD_ENDPOINT,
+            json={"option": new_option},
+            timeout=self.WRITE_TIMEOUT_SECONDS,
+        )
+
+    async def _delete_option(self, uuid: str) -> None:
+        """Delete a dnsmasq DHCP option row."""
+        await self._request(
+            "POST",
+            f"{self.OPTION_DEL_ENDPOINT}/{uuid}",
+            timeout=self.WRITE_TIMEOUT_SECONDS,
+        )
+
+    async def _reconfigure(self) -> None:
+        """Apply dnsmasq configuration changes."""
+        await self._request(
+            "POST",
+            self.RECONFIGURE_ENDPOINT,
+            timeout=self.RECONFIGURE_TIMEOUT_SECONDS,
+        )
+
+    async def set_subnet_dns(
+        self,
+        *,
+        subnet: str | None = None,
+        interface: str | None = None,
+        family: Family,
+        servers: list[str],
+    ) -> dict[str, Any]:
+        """Update scoped DNS servers for one family with rollback on failure."""
+        scope = await self.resolve_subnet_scope(subnet=subnet, interface=interface)
+        before = await self._read_option_snapshot(scope, family)
+        after = SubnetDnsSnapshot(
+            family=family,
+            servers=servers,
+            backend_payload=before.backend_payload,
+        )
+        created_new = before.backend_payload is None and not before.servers
+
+        try:
+            await self._write_option_snapshot(scope, after)
+            if created_new and after.backend_payload is None:
+                refreshed = await self._read_option_snapshot(scope, family)
+                after.backend_payload = refreshed.backend_payload
+            await self._reconfigure()
+        except Exception as exc:
+            logger.exception("dnsmasq subnet DNS update failed; rolling back")
+            restore_error: str | None = None
+            try:
+                if created_new and after.backend_payload and after.backend_payload.get(
+                    "uuid"
+                ):
+                    await self._delete_option(str(after.backend_payload["uuid"]))
+                else:
+                    await self._write_option_snapshot(scope, before)
+                await self._reconfigure()
+            except Exception as restore_exc:
+                restore_error = str(restore_exc)
+                logger.exception("dnsmasq subnet DNS rollback failed")
+            return {
+                "status": "error",
+                "backend": self.name,
+                "family": family,
+                "scope": {
+                    "interface": scope.interface,
+                    "subnet": scope.subnet,
+                    "description": scope.description,
+                },
+                "before": before.servers,
+                "attempted": servers,
+                "error": str(exc),
+                "restored": restore_error is None,
+                "restore_error": restore_error,
+            }
+
+        return {
+            "status": "success",
+            "backend": self.name,
+            "family": family,
+            "scope": {
+                "interface": scope.interface,
+                "subnet": scope.subnet,
+                "description": scope.description,
+            },
+            "before": before.servers,
+            "after": servers,
+            "applied": True,
+            "renewal_note": (
+                "DHCP clients keep prior DNS until they renew or reconnect"
+            ),
         }

--- a/opnsense_mcp/utils/dhcp_providers/dnsmasq.py
+++ b/opnsense_mcp/utils/dhcp_providers/dnsmasq.py
@@ -18,6 +18,7 @@ from opnsense_mcp.utils.dhcp_subnet_dns import (
 logger = logging.getLogger(__name__)
 
 MakeRequestFn = Callable[..., Coroutine[Any, Any, dict[str, Any] | list[Any]]]
+_UNSET: object = object()
 
 
 class DnsmasqProvider:
@@ -151,15 +152,41 @@ class DnsmasqProvider:
         response = await self._request("GET", self.OPTIONS_SEARCH_ENDPOINT)
         return extract_rows(response)
 
+    async def _load_ranges(self) -> list[dict[str, Any]]:
+        """Load all dnsmasq DHCP range rows."""
+        response = await self._request("GET", self.RANGES_SEARCH_ENDPOINT)
+        return extract_rows(response)
+
+    async def _scope_dhcp_tag(self, scope: DhcpScope) -> str | None:
+        """
+        Return the dhcp ``set_tag`` UUID applied to clients on this scope.
+
+        OPNsense tags DHCP clients from range ``set_tag`` values. Scoped DNS
+        options must use the same ``tag`` (not ``interface``) to take effect.
+        """
+        for row in await self._load_ranges():
+            row_interface = str(row.get("interface") or "").strip()
+            if not interface_matches(row_interface, scope.interface):
+                continue
+            set_tag = str(row.get("set_tag") or "").strip()
+            if set_tag:
+                return set_tag
+        return None
+
     def _option_matches_scope(
         self,
         row: dict[str, Any],
         scope: DhcpScope,
         family: Family,
+        dhcp_tag: str | None,
     ) -> bool:
         """Return True when an option row matches scope and DNS family."""
+        row_tag = str(row.get("tag") or "").strip()
         row_interface = str(row.get("interface") or "").strip()
-        if not interface_matches(row_interface, scope.interface):
+        if dhcp_tag:
+            if row_tag != dhcp_tag:
+                return False
+        elif not interface_matches(row_interface, scope.interface):
             return False
         if family == "ipv4":
             return str(row.get("option") or "").strip() == "6"
@@ -169,29 +196,34 @@ class DnsmasqProvider:
         self,
         scope: DhcpScope,
         family: Family,
+        dhcp_tag: str | None,
     ) -> dict[str, Any] | None:
         """Find the dnsmasq option row for scoped DNS servers."""
         for row in await self._load_options():
-            if self._option_matches_scope(row, scope, family):
+            if self._option_matches_scope(row, scope, family, dhcp_tag):
                 return row
         return None
 
-    async def _flat_option_payload(
+    def _flat_option_payload(
         self,
         row: dict[str, Any],
         scope: DhcpScope,
         family: Family,
         value: str,
+        dhcp_tag: str | None,
     ) -> dict[str, Any]:
         """Build a flat dnsmasq option payload accepted by set_option."""
+        use_tag = str(row.get("tag") or dhcp_tag or "")
         payload: dict[str, Any] = {
             "uuid": str(row.get("uuid") or ""),
             "type": str(row.get("type") or "set"),
-            "interface": str(row.get("interface") or scope.interface),
-            "tag": str(row.get("tag") or ""),
+            "interface": ""
+            if use_tag
+            else str(row.get("interface") or scope.interface),
+            "tag": use_tag,
             "set_tag": str(row.get("set_tag") or ""),
             "value": value,
-            "force": str(row.get("force") or "0"),
+            "force": str(row.get("force") or ("1" if use_tag else "0")),
             "description": str(row.get("description") or ""),
         }
         if family == "ipv4":
@@ -206,14 +238,19 @@ class DnsmasqProvider:
         self,
         scope: DhcpScope,
         family: Family,
+        dhcp_tag: str | None | object = _UNSET,
     ) -> SubnetDnsSnapshot:
         """Read current scoped DNS servers for one family."""
-        row = await self._find_option_row(scope, family)
+        if dhcp_tag is _UNSET:
+            resolved_tag = await self._scope_dhcp_tag(scope)
+        else:
+            resolved_tag = dhcp_tag
+        row = await self._find_option_row(scope, family, resolved_tag)
         if not row:
             return SubnetDnsSnapshot(family=family, servers=[], backend_payload=None)
         value = str(row.get("value") or "")
         servers = parse_dns_server_list(value, family)
-        payload = await self._flat_option_payload(row, scope, family, value)
+        payload = self._flat_option_payload(row, scope, family, value, resolved_tag)
         return SubnetDnsSnapshot(
             family=family,
             servers=servers,
@@ -228,8 +265,9 @@ class DnsmasqProvider:
     ) -> dict[str, Any]:
         """Return scoped IPv4/IPv6 DNS servers from dnsmasq DHCP options."""
         scope = await self.resolve_subnet_scope(subnet=subnet, interface=interface)
-        ipv4 = await self._read_option_snapshot(scope, "ipv4")
-        ipv6 = await self._read_option_snapshot(scope, "ipv6")
+        dhcp_tag = await self._scope_dhcp_tag(scope)
+        ipv4 = await self._read_option_snapshot(scope, "ipv4", dhcp_tag)
+        ipv6 = await self._read_option_snapshot(scope, "ipv6", dhcp_tag)
         return {
             "backend": self.name,
             "scope": {
@@ -245,6 +283,7 @@ class DnsmasqProvider:
         self,
         scope: DhcpScope,
         snapshot: SubnetDnsSnapshot,
+        dhcp_tag: str | None | object = _UNSET,
     ) -> None:
         """Write one dnsmasq option snapshot for rollback or apply."""
         family = snapshot.family
@@ -254,9 +293,7 @@ class DnsmasqProvider:
         if payload and payload.get("uuid"):
             uuid = str(payload["uuid"])
             option_data = {
-                key: value
-                for key, value in payload.items()
-                if key != "uuid"
+                key: value for key, value in payload.items() if key != "uuid"
             }
             option_data["value"] = formatted
             await self._request(
@@ -270,12 +307,16 @@ class DnsmasqProvider:
         if not snapshot.servers:
             return
 
+        if dhcp_tag is _UNSET:
+            resolved_tag = await self._scope_dhcp_tag(scope)
+        else:
+            resolved_tag = dhcp_tag
         new_option: dict[str, Any] = {
             "type": "set",
-            "interface": scope.interface,
+            "interface": "" if resolved_tag else scope.interface,
             "value": formatted,
-            "force": "0",
-            "tag": "",
+            "force": "1" if resolved_tag else "0",
+            "tag": resolved_tag or "",
             "set_tag": "",
             "description": "",
         }
@@ -318,7 +359,8 @@ class DnsmasqProvider:
     ) -> dict[str, Any]:
         """Update scoped DNS servers for one family with rollback on failure."""
         scope = await self.resolve_subnet_scope(subnet=subnet, interface=interface)
-        before = await self._read_option_snapshot(scope, family)
+        dhcp_tag = await self._scope_dhcp_tag(scope)
+        before = await self._read_option_snapshot(scope, family, dhcp_tag)
         after = SubnetDnsSnapshot(
             family=family,
             servers=servers,
@@ -327,21 +369,23 @@ class DnsmasqProvider:
         created_new = before.backend_payload is None and not before.servers
 
         try:
-            await self._write_option_snapshot(scope, after)
+            await self._write_option_snapshot(scope, after, dhcp_tag)
             if created_new and after.backend_payload is None:
-                refreshed = await self._read_option_snapshot(scope, family)
+                refreshed = await self._read_option_snapshot(scope, family, dhcp_tag)
                 after.backend_payload = refreshed.backend_payload
             await self._reconfigure()
         except Exception as exc:
             logger.exception("dnsmasq subnet DNS update failed; rolling back")
             restore_error: str | None = None
             try:
-                if created_new and after.backend_payload and after.backend_payload.get(
-                    "uuid"
+                if (
+                    created_new
+                    and after.backend_payload
+                    and after.backend_payload.get("uuid")
                 ):
                     await self._delete_option(str(after.backend_payload["uuid"]))
                 else:
-                    await self._write_option_snapshot(scope, before)
+                    await self._write_option_snapshot(scope, before, dhcp_tag)
                 await self._reconfigure()
             except Exception as restore_exc:
                 restore_error = str(restore_exc)

--- a/opnsense_mcp/utils/dhcp_providers/kea.py
+++ b/opnsense_mcp/utils/dhcp_providers/kea.py
@@ -4,6 +4,15 @@ import logging
 from collections.abc import Callable, Coroutine
 from typing import Any
 
+from opnsense_mcp.utils.dhcp_scope import resolve_kea_scope
+from opnsense_mcp.utils.dhcp_subnet_dns import (
+    DhcpScope,
+    Family,
+    SubnetDnsSnapshot,
+    parse_dns_server_list,
+    unwrap_model_payload,
+)
+
 logger = logging.getLogger(__name__)
 
 MakeRequestFn = Callable[..., Coroutine[Any, Any, dict[str, Any] | list[Any]]]
@@ -16,6 +25,14 @@ class KeaProvider:
     V4_LEASE_ENDPOINT = "/api/kea/leases4/search"
     V6_LEASE_ENDPOINT = "/api/kea/leases6/search"
     SERVICE_STATUS_ENDPOINT = "/api/kea/service/status"
+    V4_SUBNET_SEARCH_ENDPOINT = "/api/kea/dhcpv4/search_subnet"
+    V6_SUBNET_SEARCH_ENDPOINT = "/api/kea/dhcpv6/search_subnet"
+    V4_SUBNET_GET_ENDPOINT = "/api/kea/dhcpv4/get_subnet"
+    V6_SUBNET_GET_ENDPOINT = "/api/kea/dhcpv6/get_subnet"
+    V4_SUBNET_SET_ENDPOINT = "/api/kea/dhcpv4/set_subnet"
+    V6_SUBNET_SET_ENDPOINT = "/api/kea/dhcpv6/set_subnet"
+    RECONFIGURE_ENDPOINT = "/api/kea/service/reconfigure"
+    SUBNET_DNS_SUPPORTED = True
 
     def __init__(self, make_request: MakeRequestFn) -> None:
         """Initialize provider with request function."""
@@ -98,4 +115,223 @@ class KeaProvider:
             "status": "error",
             "error": "Lease deletion not supported by Kea backend",
             "ip": ip,
+        }
+
+    def _subnet_model_key(self, family: Family) -> str:
+        """Return the Kea subnet payload key for a family."""
+        return "subnet4" if family == "ipv4" else "subnet6"
+
+    def _subnet_get_endpoint(self, family: Family) -> str:
+        """Return the Kea get_subnet endpoint prefix for a family."""
+        return (
+            self.V4_SUBNET_GET_ENDPOINT
+            if family == "ipv4"
+            else self.V6_SUBNET_GET_ENDPOINT
+        )
+
+    def _subnet_set_endpoint(self, family: Family) -> str:
+        """Return the Kea set_subnet endpoint prefix for a family."""
+        return (
+            self.V4_SUBNET_SET_ENDPOINT
+            if family == "ipv4"
+            else self.V6_SUBNET_SET_ENDPOINT
+        )
+
+    async def _load_subnet_payload(
+        self,
+        uuid: str,
+        family: Family,
+    ) -> dict[str, Any]:
+        """Load the full Kea subnet model payload."""
+        response = await self._request(
+            "GET",
+            f"{self._subnet_get_endpoint(family)}/{uuid}",
+        )
+        model_key = self._subnet_model_key(family)
+        payload = unwrap_model_payload(response, model_key, "subnet")
+        payload["uuid"] = uuid
+        return payload
+
+    def _extract_dns_servers(
+        self,
+        subnet_payload: dict[str, Any],
+        family: Family,
+    ) -> list[str]:
+        """Extract DNS servers from a Kea subnet payload."""
+        option_data = subnet_payload.get("option_data")
+        if not isinstance(option_data, dict):
+            return []
+        dns_entry = option_data.get("domain_name_servers")
+        if isinstance(dns_entry, dict):
+            raw = str(dns_entry.get("value") or "")
+        else:
+            raw = str(dns_entry or "")
+        return parse_dns_server_list(raw, family)
+
+    def _apply_dns_servers_to_payload(
+        self,
+        subnet_payload: dict[str, Any],
+        family: Family,
+        servers: list[str],
+    ) -> dict[str, Any]:
+        """Return a subnet payload with updated DNS servers."""
+        updated = dict(subnet_payload)
+        updated["option_data_autocollect"] = "0"
+        option_data = updated.get("option_data")
+        if not isinstance(option_data, dict):
+            option_data = {}
+        option_data = dict(option_data)
+        option_data["domain_name_servers"] = {
+            "value": ",".join(servers),
+            "selected": 1,
+        }
+        updated["option_data"] = option_data
+        return updated
+
+    async def _read_subnet_snapshot(
+        self,
+        *,
+        subnet: str | None,
+        interface: str | None,
+        family: Family,
+    ) -> tuple[DhcpScope, SubnetDnsSnapshot]:
+        """Read current DNS servers and full subnet payload for rollback."""
+        scope, row = await resolve_kea_scope(
+            self._request,
+            subnet=subnet,
+            interface=interface,
+            family=family,
+        )
+        uuid = str(row.get("uuid") or "")
+        if not uuid:
+            msg = f"Kea {family} subnet row is missing uuid"
+            raise ValueError(msg)
+        payload = await self._load_subnet_payload(uuid, family)
+        servers = self._extract_dns_servers(payload, family)
+        return scope, SubnetDnsSnapshot(
+            family=family,
+            servers=servers,
+            backend_payload=payload,
+        )
+
+    async def _write_subnet_snapshot(
+        self,
+        snapshot: SubnetDnsSnapshot,
+    ) -> None:
+        """Write a Kea subnet payload."""
+        payload = snapshot.backend_payload
+        if not payload or not payload.get("uuid"):
+            msg = "Missing Kea subnet payload for write"
+            raise ValueError(msg)
+        uuid = str(payload["uuid"])
+        family = snapshot.family
+        model_key = self._subnet_model_key(family)
+        await self._request(
+            "POST",
+            f"{self._subnet_set_endpoint(family)}/{uuid}",
+            json={model_key: payload},
+        )
+
+    async def list_subnet_dns(
+        self,
+        *,
+        subnet: str | None = None,
+        interface: str | None = None,
+    ) -> dict[str, Any]:
+        """Return scoped IPv4/IPv6 DNS servers from Kea subnet option data."""
+        scope_v4, ipv4 = await self._read_subnet_snapshot(
+            subnet=subnet,
+            interface=interface,
+            family="ipv4",
+        )
+        try:
+            _, ipv6 = await self._read_subnet_snapshot(
+                subnet=subnet,
+                interface=interface,
+                family="ipv6",
+            )
+            ipv6_servers = ipv6.servers
+        except ValueError:
+            ipv6_servers = []
+
+        return {
+            "backend": self.name,
+            "scope": {
+                "interface": scope_v4.interface,
+                "subnet": scope_v4.subnet,
+                "description": scope_v4.description,
+            },
+            "ipv4": ipv4.servers,
+            "ipv6": ipv6_servers,
+        }
+
+    async def set_subnet_dns(
+        self,
+        *,
+        subnet: str | None = None,
+        interface: str | None = None,
+        family: Family,
+        servers: list[str],
+    ) -> dict[str, Any]:
+        """Update scoped DNS servers for one family with rollback on failure."""
+        scope, before = await self._read_subnet_snapshot(
+            subnet=subnet,
+            interface=interface,
+            family=family,
+        )
+        payload = before.backend_payload
+        if not payload:
+            msg = f"No Kea {family} subnet payload available for update"
+            raise ValueError(msg)
+
+        after_payload = self._apply_dns_servers_to_payload(payload, family, servers)
+        after = SubnetDnsSnapshot(
+            family=family,
+            servers=servers,
+            backend_payload=after_payload,
+        )
+
+        try:
+            await self._write_subnet_snapshot(after)
+            await self._request("POST", self.RECONFIGURE_ENDPOINT)
+        except Exception as exc:
+            logger.exception("Kea subnet DNS update failed; rolling back")
+            restore_error: str | None = None
+            try:
+                await self._write_subnet_snapshot(before)
+                await self._request("POST", self.RECONFIGURE_ENDPOINT)
+            except Exception as restore_exc:
+                restore_error = str(restore_exc)
+                logger.exception("Kea subnet DNS rollback failed")
+            return {
+                "status": "error",
+                "backend": self.name,
+                "family": family,
+                "scope": {
+                    "interface": scope.interface,
+                    "subnet": scope.subnet,
+                    "description": scope.description,
+                },
+                "before": before.servers,
+                "attempted": servers,
+                "error": str(exc),
+                "restored": restore_error is None,
+                "restore_error": restore_error,
+            }
+
+        return {
+            "status": "success",
+            "backend": self.name,
+            "family": family,
+            "scope": {
+                "interface": scope.interface,
+                "subnet": scope.subnet,
+                "description": scope.description,
+            },
+            "before": before.servers,
+            "after": servers,
+            "applied": True,
+            "renewal_note": (
+                "DHCP clients keep prior DNS until they renew or reconnect"
+            ),
         }

--- a/opnsense_mcp/utils/dhcp_scope.py
+++ b/opnsense_mcp/utils/dhcp_scope.py
@@ -1,0 +1,260 @@
+"""Resolve DHCP scopes from subnet CIDR and/or interface selectors."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from opnsense_mcp.utils.dhcp_subnet_dns import (
+    DhcpScope,
+    cidr_matches,
+    extract_rows,
+    interface_matches,
+    normalize_cidr,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def load_interface_overview(
+    make_request: Any,
+) -> dict[str, dict[str, Any]]:
+    """Load interface overview export keyed by interface identifier."""
+    merged: dict[str, dict[str, Any]] = {}
+    try:
+        response = await make_request("GET", "/api/interfaces/overview/export")
+    except Exception:
+        logger.exception("Failed to fetch interface overview export")
+        return merged
+
+    if isinstance(response, list):
+        for entry in response:
+            if not isinstance(entry, dict):
+                continue
+            key = (
+                entry.get("identifier")
+                or entry.get("device")
+                or entry.get("name")
+                or ""
+            )
+            if key:
+                merged[str(key)] = entry
+    elif isinstance(response, dict):
+        for key, value in response.items():
+            if isinstance(value, dict):
+                merged[str(key)] = value
+    return merged
+
+
+def resolve_interface_key(
+    selector: str,
+    overview: dict[str, dict[str, Any]],
+) -> str | None:
+    """Resolve a user interface selector to an OPNsense interface key."""
+    needle = selector.strip()
+    if not needle:
+        return None
+
+    if needle in overview:
+        return needle
+
+    needle_lc = needle.lower()
+    for key, entry in overview.items():
+        candidates = [
+            key,
+            str(entry.get("identifier") or ""),
+            str(entry.get("description") or ""),
+            str(entry.get("device") or ""),
+            str(entry.get("name") or ""),
+        ]
+        if any(candidate and candidate.lower() == needle_lc for candidate in candidates):
+            return key
+    return None
+
+
+def interface_ipv4_network(
+    interface_key: str,
+    overview: dict[str, dict[str, Any]],
+) -> str | None:
+    """Return the primary IPv4 network for an interface, if known."""
+    entry = overview.get(interface_key, {})
+    for field in ("subnet", "ipaddr", "address"):
+        raw = entry.get(field)
+        if not raw or not str(raw).strip():
+            continue
+        value = str(raw).strip()
+        if "/" in value:
+            try:
+                return normalize_cidr(value)
+            except ValueError:
+                continue
+        if field == "ipaddr":
+            prefix = str(entry.get("subnet") or "").strip()
+            if prefix.isdigit():
+                try:
+                    return normalize_cidr(f"{value}/{prefix}")
+                except ValueError:
+                    continue
+    return None
+
+
+async def resolve_scope_from_selectors(
+    make_request: Any,
+    *,
+    subnet: str | None,
+    interface: str | None,
+    range_search_endpoint: str,
+) -> DhcpScope:
+    """
+    Resolve subnet/interface selectors to a DHCP scope.
+
+    ``range_search_endpoint`` is backend-specific (dnsmasq ranges or Kea subnets).
+    """
+    if not subnet and not interface:
+        msg = "Provide subnet (CIDR) and/or interface"
+        raise ValueError(msg)
+
+    overview = await load_interface_overview(make_request)
+    resolved_interface = (
+        resolve_interface_key(interface, overview) if interface else None
+    )
+    if interface and not resolved_interface:
+        msg = f"Unknown interface {interface!r}"
+        raise ValueError(msg)
+
+    normalized_subnet = normalize_cidr(subnet) if subnet else None
+    if normalized_subnet and resolved_interface:
+        iface_subnet = interface_ipv4_network(resolved_interface, overview)
+        if iface_subnet and not cidr_matches(normalized_subnet, iface_subnet):
+            msg = (
+                f"Subnet {normalized_subnet} does not match interface "
+                f"{resolved_interface} network {iface_subnet}"
+            )
+            raise ValueError(msg)
+        description = overview.get(resolved_interface, {}).get("description")
+        return DhcpScope(
+            interface=resolved_interface,
+            subnet=normalized_subnet,
+            description=str(description) if description else None,
+        )
+
+    if resolved_interface:
+        iface_subnet = interface_ipv4_network(resolved_interface, overview)
+        description = overview.get(resolved_interface, {}).get("description")
+        return DhcpScope(
+            interface=resolved_interface,
+            subnet=iface_subnet,
+            description=str(description) if description else None,
+        )
+
+    assert normalized_subnet is not None
+    response = await make_request("GET", range_search_endpoint)
+    rows = extract_rows(response)
+    for row in rows:
+        row_subnet = str(
+            row.get("subnet")
+            or row.get("network")
+            or row.get("range")
+            or ""
+        ).strip()
+        row_interface = str(row.get("interface") or "").strip()
+        if row_subnet and cidr_matches(row_subnet, normalized_subnet):
+            if not row_interface:
+                msg = f"No interface mapped to subnet {normalized_subnet}"
+                raise ValueError(msg)
+            return DhcpScope(
+                interface=row_interface,
+                subnet=normalized_subnet,
+                description=str(row.get("description") or "") or None,
+            )
+        start = str(row.get("start") or row.get("rangestart") or "").strip()
+        end = str(row.get("end") or row.get("rangeend") or "").strip()
+        if start and end:
+            try:
+                candidate = normalize_cidr(f"{start}/{normalized_subnet.split('/')[1]}")
+            except (IndexError, ValueError):
+                candidate = ""
+            if candidate and cidr_matches(candidate, normalized_subnet):
+                if not row_interface:
+                    msg = f"No interface mapped to subnet {normalized_subnet}"
+                    raise ValueError(msg)
+                return DhcpScope(
+                    interface=row_interface,
+                    subnet=normalized_subnet,
+                    description=str(row.get("description") or "") or None,
+                )
+
+    msg = f"No DHCP scope found for subnet {normalized_subnet}"
+    raise ValueError(msg)
+
+
+async def resolve_kea_scope(
+    make_request: Any,
+    *,
+    subnet: str | None,
+    interface: str | None,
+    family: str,
+) -> tuple[DhcpScope, dict[str, Any]]:
+    """Resolve scope and return the matching Kea subnet row."""
+    endpoint = (
+        "/api/kea/dhcpv4/search_subnet"
+        if family == "ipv4"
+        else "/api/kea/dhcpv6/search_subnet"
+    )
+    resolved_interface: str | None = None
+    overview: dict[str, dict[str, Any]] = {}
+    if interface:
+        overview = await load_interface_overview(make_request)
+        resolved_interface = resolve_interface_key(interface, overview)
+        if not resolved_interface:
+            msg = f"Unknown interface {interface!r}"
+            raise ValueError(msg)
+
+    normalized_subnet = normalize_cidr(subnet) if subnet else None
+    response = await make_request("GET", endpoint)
+    rows = extract_rows(response)
+
+    if normalized_subnet:
+        for row in rows:
+            row_subnet = str(row.get("subnet") or "").strip()
+            if row_subnet and cidr_matches(row_subnet, normalized_subnet):
+                return (
+                    DhcpScope(
+                        interface=resolved_interface or str(row.get("interface") or ""),
+                        subnet=normalized_subnet,
+                        description=str(row.get("description") or "") or None,
+                    ),
+                    row,
+                )
+        msg = f"No Kea {family} subnet found for {normalized_subnet}"
+        raise ValueError(msg)
+
+    assert resolved_interface is not None
+    if not overview:
+        overview = await load_interface_overview(make_request)
+    iface_subnet = interface_ipv4_network(resolved_interface, overview)
+    for row in rows:
+        row_interface = str(row.get("interface") or "").strip()
+        if row_interface and interface_matches(row_interface, resolved_interface):
+            row_subnet = str(row.get("subnet") or "").strip() or iface_subnet
+            return (
+                DhcpScope(
+                    interface=resolved_interface,
+                    subnet=row_subnet or None,
+                    description=str(row.get("description") or "") or None,
+                ),
+                row,
+            )
+        row_subnet = str(row.get("subnet") or "").strip()
+        if iface_subnet and row_subnet and cidr_matches(row_subnet, iface_subnet):
+            return (
+                DhcpScope(
+                    interface=resolved_interface,
+                    subnet=row_subnet,
+                    description=str(row.get("description") or "") or None,
+                ),
+                row,
+            )
+
+    msg = f"No Kea {family} subnet found for interface {resolved_interface}"
+    raise ValueError(msg)

--- a/opnsense_mcp/utils/dhcp_subnet_dns.py
+++ b/opnsense_mcp/utils/dhcp_subnet_dns.py
@@ -1,0 +1,201 @@
+"""Shared helpers for DHCP per-subnet DNS configuration."""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+from dataclasses import dataclass
+from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
+
+Family = Literal["ipv4", "ipv6"]
+MAX_DNS_SLOTS = 2
+
+
+@dataclass(frozen=True)
+class DhcpScope:
+    """Resolved DHCP scope for subnet DNS operations."""
+
+    interface: str
+    subnet: str | None = None
+    description: str | None = None
+
+
+@dataclass
+class SubnetDnsSnapshot:
+    """Stored DNS state for one address family within a scope."""
+
+    family: Family
+    servers: list[str]
+    backend_payload: dict[str, Any] | None = None
+
+
+def normalize_family(value: str) -> Family:
+    """Normalize and validate an address family string."""
+    family = value.strip().lower()
+    if family in {"ipv4", "v4", "inet"}:
+        return "ipv4"
+    if family in {"ipv6", "v6", "inet6"}:
+        return "ipv6"
+    msg = f"Invalid family {value!r}; expected ipv4 or ipv6"
+    raise ValueError(msg)
+
+
+def validate_address(address: str, family: Family) -> str:
+    """Validate an IP address for the requested family."""
+    cleaned = address.strip()
+    if not cleaned:
+        msg = "Empty DNS server address is not allowed"
+        raise ValueError(msg)
+    try:
+        parsed = ipaddress.ip_address(cleaned)
+    except ValueError as exc:
+        msg = f"Invalid IP address for {family}: {address!r}"
+        raise ValueError(msg) from exc
+    if family == "ipv4" and parsed.version != 4:
+        msg = f"Expected IPv4 address, got {address!r}"
+        raise ValueError(msg)
+    if family == "ipv6" and parsed.version != 6:
+        msg = f"Expected IPv6 address, got {address!r}"
+        raise ValueError(msg)
+    return cleaned
+
+
+def validate_addresses(addresses: list[str], family: Family) -> list[str]:
+    """Validate a list of DNS server addresses."""
+    if not addresses:
+        msg = "At least one DNS server address is required"
+        raise ValueError(msg)
+    if len(addresses) > MAX_DNS_SLOTS:
+        msg = f"At most {MAX_DNS_SLOTS} DNS servers are allowed per family"
+        raise ValueError(msg)
+    return [validate_address(item, family) for item in addresses]
+
+
+def parse_dns_server_list(raw: str, family: Family) -> list[str]:
+    """Parse a comma-separated DNS server list from backend config."""
+    if not raw or not str(raw).strip():
+        return []
+    servers: list[str] = []
+    for part in str(raw).split(","):
+        token = part.strip()
+        if not token:
+            continue
+        if family == "ipv6" and token.startswith("[") and token.endswith("]"):
+            token = token[1:-1].strip()
+        servers.append(validate_address(token, family))
+    return servers[:MAX_DNS_SLOTS]
+
+
+def format_dns_server_list(servers: list[str], family: Family) -> str:
+    """Format DNS servers for backend storage."""
+    cleaned = validate_addresses(servers, family) if servers else []
+    if family == "ipv6":
+        return ",".join(f"[{addr}]" for addr in cleaned)
+    return ",".join(cleaned)
+
+
+def merge_slot_update(
+    current: list[str],
+    *,
+    dns_server: str | None = None,
+    dns_servers: list[str] | None = None,
+    slot: int | None = None,
+    family: Family,
+) -> list[str]:
+    """
+    Merge a slot-oriented DNS update into the current server list.
+
+    Single address updates slot 1 by default; pass slot=2 to update secondary.
+    """
+    if dns_server and dns_servers is not None:
+        msg = "Provide either dns_server or dns_servers, not both"
+        raise ValueError(msg)
+    if dns_server is None and dns_servers is None:
+        msg = "Provide dns_server or dns_servers"
+        raise ValueError(msg)
+
+    slots: list[str | None] = [
+        current[0] if len(current) > 0 else None,
+        current[1] if len(current) > 1 else None,
+    ]
+
+    if dns_servers is not None:
+        if len(dns_servers) == 0:
+            msg = "Empty dns_servers list is not allowed"
+            raise ValueError(msg)
+        validated = validate_addresses(dns_servers, family)
+        if len(validated) == 1:
+            target = slot or 1
+            if target not in (1, 2):
+                msg = "slot must be 1 or 2"
+                raise ValueError(msg)
+            slots[target - 1] = validated[0]
+        else:
+            slots[0], slots[1] = validated[0], validated[1]
+    else:
+        assert dns_server is not None
+        validated_one = validate_address(dns_server, family)
+        target = slot or 1
+        if target not in (1, 2):
+            msg = "slot must be 1 or 2"
+            raise ValueError(msg)
+        slots[target - 1] = validated_one
+
+    merged = [item for item in slots if item]
+    return validate_addresses(merged, family) if merged else []
+
+
+def extract_rows(response: dict[str, Any] | list[Any]) -> list[dict[str, Any]]:
+    """Extract record rows from common OPNsense list responses."""
+    if isinstance(response, list):
+        return [row for row in response if isinstance(row, dict)]
+    if isinstance(response, dict):
+        rows = response.get("rows")
+        if isinstance(rows, list):
+            return [row for row in rows if isinstance(row, dict)]
+    return []
+
+
+def normalize_cidr(value: str) -> str:
+    """Return canonical network CIDR notation."""
+    network = ipaddress.ip_network(value.strip(), strict=False)
+    return f"{network.network_address}/{network.prefixlen}"
+
+
+def cidr_matches(value: str, target: str) -> bool:
+    """Return True when two CIDR strings refer to the same network."""
+    try:
+        return normalize_cidr(value) == normalize_cidr(target)
+    except ValueError:
+        return False
+
+
+def network_contains_ip(cidr: str, ip_value: str) -> bool:
+    """Return True when an IP belongs to a CIDR network."""
+    try:
+        network = ipaddress.ip_network(cidr, strict=False)
+        address = ipaddress.ip_address(ip_value.strip())
+        return address in network
+    except ValueError:
+        return False
+
+
+def unwrap_model_payload(
+    response: dict[str, Any] | list[Any],
+    *keys: str,
+) -> dict[str, Any]:
+    """Unwrap nested OPNsense model payloads such as {"option": {...}}."""
+    if not isinstance(response, dict):
+        return {}
+    for key in keys:
+        nested = response.get(key)
+        if isinstance(nested, dict):
+            return nested
+    return response
+
+
+def interface_matches(candidate: str, target: str) -> bool:
+    """Compare interface identifiers case-insensitively."""
+    return candidate.strip().lower() == target.strip().lower()

--- a/tests/test_dhcp_subnet_dns_common.py
+++ b/tests/test_dhcp_subnet_dns_common.py
@@ -1,0 +1,65 @@
+"""Tests for DHCP subnet DNS slot helpers."""
+
+import pytest
+
+from opnsense_mcp.utils.dhcp_subnet_dns import (
+    format_dns_server_list,
+    merge_slot_update,
+    parse_dns_server_list,
+    validate_address,
+)
+
+
+def test_merge_single_address_updates_slot_one() -> None:
+    merged = merge_slot_update(
+        ["10.0.10.5"],
+        dns_server="10.0.10.4",
+        family="ipv4",
+    )
+    assert merged == ["10.0.10.4"]
+
+
+def test_merge_single_address_updates_slot_two() -> None:
+    merged = merge_slot_update(
+        ["10.0.10.4"],
+        dns_server="10.0.10.5",
+        slot=2,
+        family="ipv4",
+    )
+    assert merged == ["10.0.10.4", "10.0.10.5"]
+
+
+def test_merge_two_addresses_replace_both_slots() -> None:
+    merged = merge_slot_update(
+        ["10.0.10.1"],
+        dns_servers=["10.0.10.4", "10.0.10.5"],
+        family="ipv4",
+    )
+    assert merged == ["10.0.10.4", "10.0.10.5"]
+
+
+def test_merge_rejects_empty_dns_servers() -> None:
+    with pytest.raises(ValueError, match="Empty dns_servers"):
+        merge_slot_update([], dns_servers=[], family="ipv4")
+
+
+def test_merge_rejects_both_single_and_list() -> None:
+    with pytest.raises(ValueError, match="not both"):
+        merge_slot_update(
+            [],
+            dns_server="10.0.10.4",
+            dns_servers=["10.0.10.5"],
+            family="ipv4",
+        )
+
+
+def test_parse_and_format_ipv6_with_brackets() -> None:
+    parsed = parse_dns_server_list("[2601:441:8483:b501::44]", "ipv6")
+    assert parsed == ["2601:441:8483:b501::44"]
+    formatted = format_dns_server_list(parsed, "ipv6")
+    assert formatted == "[2601:441:8483:b501::44]"
+
+
+def test_validate_address_family_mismatch() -> None:
+    with pytest.raises(ValueError, match="Expected IPv4"):
+        validate_address("2601:441:8483:b501::44", "ipv4")

--- a/tests/test_dhcp_subnet_dns_dnsmasq.py
+++ b/tests/test_dhcp_subnet_dns_dnsmasq.py
@@ -1,0 +1,139 @@
+"""Tests for dnsmasq subnet DNS provider methods."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from opnsense_mcp.utils.dhcp_providers.dnsmasq import DnsmasqProvider
+
+
+@pytest.fixture
+def make_request() -> AsyncMock:
+    """Create a mock request callable."""
+    return AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_list_subnet_dns_reads_scoped_options(make_request: AsyncMock) -> None:
+    make_request.side_effect = [
+        {
+            "opt2": {
+                "identifier": "opt2",
+                "description": "VLAN2wired",
+                "ipaddr": "10.0.2.1",
+                "subnet": "24",
+            }
+        },
+        {
+            "rows": [
+                {
+                    "uuid": "opt-v4",
+                    "interface": "opt2",
+                    "option": "6",
+                    "value": "10.0.10.4,10.0.10.5",
+                },
+                {
+                    "uuid": "opt-v6",
+                    "interface": "opt2",
+                    "option6": "23",
+                    "value": "[2601:441:8483:b501::44]",
+                },
+            ]
+        },
+        {
+            "rows": [
+                {
+                    "uuid": "opt-v4",
+                    "interface": "opt2",
+                    "option": "6",
+                    "value": "10.0.10.4,10.0.10.5",
+                },
+                {
+                    "uuid": "opt-v6",
+                    "interface": "opt2",
+                    "option6": "23",
+                    "value": "[2601:441:8483:b501::44]",
+                },
+            ]
+        },
+    ]
+
+    provider = DnsmasqProvider(make_request)
+    result = await provider.list_subnet_dns(interface="opt2")
+
+    assert result["backend"] == "dnsmasq"
+    assert result["scope"]["interface"] == "opt2"
+    assert result["ipv4"] == ["10.0.10.4", "10.0.10.5"]
+    assert result["ipv6"] == ["2601:441:8483:b501::44"]
+
+
+@pytest.mark.asyncio
+async def test_set_subnet_dns_updates_and_reconfigures(make_request: AsyncMock) -> None:
+    make_request.side_effect = [
+        {"opt2": {"identifier": "opt2", "ipaddr": "10.0.2.1", "subnet": "24"}},
+        {
+            "rows": [
+                {
+                    "uuid": "opt-v4",
+                    "interface": "opt2",
+                    "option": "6",
+                    "value": "10.0.10.5",
+                }
+            ]
+        },
+        {"uuid": "opt-v4", "interface": "opt2", "option": "6", "value": "10.0.10.5"},
+        {"result": "saved"},
+        {"result": "done"},
+    ]
+
+    provider = DnsmasqProvider(make_request)
+    result = await provider.set_subnet_dns(
+        interface="opt2",
+        family="ipv4",
+        servers=["10.0.10.4"],
+    )
+
+    assert result["status"] == "success"
+    assert result["before"] == ["10.0.10.5"]
+    assert result["after"] == ["10.0.10.4"]
+    set_calls = [
+        call
+        for call in make_request.call_args_list
+        if call.args[:2] == ("POST", "/api/dnsmasq/settings/set_option/opt-v4")
+    ]
+    assert set_calls
+    assert set_calls[0].kwargs["json"]["option"]["value"] == "10.0.10.4"
+
+
+@pytest.mark.asyncio
+async def test_set_subnet_dns_rolls_back_on_reconfigure_failure(
+    make_request: AsyncMock,
+) -> None:
+    make_request.side_effect = [
+        {"opt2": {"identifier": "opt2", "ipaddr": "10.0.2.1", "subnet": "24"}},
+        {
+            "rows": [
+                {
+                    "uuid": "opt-v4",
+                    "interface": "opt2",
+                    "option": "6",
+                    "value": "10.0.10.5",
+                }
+            ]
+        },
+        {"result": "saved"},
+        RuntimeError("reconfigure failed"),
+        {"result": "saved"},
+        {"result": "done"},
+    ]
+
+    provider = DnsmasqProvider(make_request)
+    result = await provider.set_subnet_dns(
+        interface="opt2",
+        family="ipv4",
+        servers=["10.0.10.4"],
+    )
+
+    assert result["status"] == "error"
+    assert result["restored"] is True
+    assert result["before"] == ["10.0.10.5"]

--- a/tests/test_dhcp_subnet_dns_dnsmasq.py
+++ b/tests/test_dhcp_subnet_dns_dnsmasq.py
@@ -24,6 +24,7 @@ async def test_list_subnet_dns_reads_scoped_options(make_request: AsyncMock) -> 
                 "subnet": "24",
             }
         },
+        {"rows": []},
         {
             "rows": [
                 {
@@ -71,6 +72,7 @@ async def test_list_subnet_dns_reads_scoped_options(make_request: AsyncMock) -> 
 async def test_set_subnet_dns_updates_and_reconfigures(make_request: AsyncMock) -> None:
     make_request.side_effect = [
         {"opt2": {"identifier": "opt2", "ipaddr": "10.0.2.1", "subnet": "24"}},
+        {"rows": []},
         {
             "rows": [
                 {
@@ -81,7 +83,7 @@ async def test_set_subnet_dns_updates_and_reconfigures(make_request: AsyncMock) 
                 }
             ]
         },
-        {"uuid": "opt-v4", "interface": "opt2", "option": "6", "value": "10.0.10.5"},
+        {"rows": []},
         {"result": "saved"},
         {"result": "done"},
     ]
@@ -111,6 +113,7 @@ async def test_set_subnet_dns_rolls_back_on_reconfigure_failure(
 ) -> None:
     make_request.side_effect = [
         {"opt2": {"identifier": "opt2", "ipaddr": "10.0.2.1", "subnet": "24"}},
+        {"rows": []},
         {
             "rows": [
                 {
@@ -137,3 +140,105 @@ async def test_set_subnet_dns_rolls_back_on_reconfigure_failure(
     assert result["status"] == "error"
     assert result["restored"] is True
     assert result["before"] == ["10.0.10.5"]
+
+
+@pytest.mark.asyncio
+async def test_list_subnet_dns_uses_dhcp_range_tag(make_request: AsyncMock) -> None:
+    internal_tag = "97f6eab8-edd3-4390-a721-dfe9584c6b73"
+    make_request.side_effect = [
+        {
+            "opt5": {
+                "identifier": "opt5",
+                "description": "VLAN81wifi",
+                "ipaddr": "10.0.8.1",
+                "subnet": "24",
+            }
+        },
+        {
+            "rows": [
+                {
+                    "interface": "opt5",
+                    "set_tag": internal_tag,
+                    "start_addr": "10.0.8.2",
+                    "end_addr": "10.0.8.240",
+                }
+            ]
+        },
+        {
+            "rows": [
+                {
+                    "uuid": "opt-v4",
+                    "interface": "",
+                    "tag": internal_tag,
+                    "option": "6",
+                    "value": "10.0.2.2,10.0.10.46",
+                    "force": "1",
+                }
+            ]
+        },
+        {"rows": []},
+    ]
+
+    provider = DnsmasqProvider(make_request)
+    result = await provider.list_subnet_dns(interface="opt5")
+
+    assert result["ipv4"] == ["10.0.2.2", "10.0.10.46"]
+
+
+@pytest.mark.asyncio
+async def test_set_subnet_dns_creates_tagged_option(make_request: AsyncMock) -> None:
+    internal_tag = "97f6eab8-edd3-4390-a721-dfe9584c6b73"
+    make_request.side_effect = [
+        {
+            "opt5": {
+                "identifier": "opt5",
+                "ipaddr": "10.0.8.1",
+                "subnet": "24",
+            }
+        },
+        {
+            "rows": [
+                {
+                    "interface": "opt5",
+                    "set_tag": internal_tag,
+                    "start_addr": "10.0.8.2",
+                    "end_addr": "10.0.8.240",
+                }
+            ]
+        },
+        {"rows": []},
+        {"result": "added"},
+        {
+            "rows": [
+                {
+                    "uuid": "new-opt-v4",
+                    "interface": "",
+                    "tag": internal_tag,
+                    "option": "6",
+                    "value": "10.0.2.2,10.0.10.46",
+                    "force": "1",
+                }
+            ]
+        },
+        {"result": "done"},
+    ]
+
+    provider = DnsmasqProvider(make_request)
+    result = await provider.set_subnet_dns(
+        interface="opt5",
+        family="ipv4",
+        servers=["10.0.2.2", "10.0.10.46"],
+    )
+
+    assert result["status"] == "success"
+    add_calls = [
+        call
+        for call in make_request.call_args_list
+        if call.args[:2] == ("POST", "/api/dnsmasq/settings/add_option")
+    ]
+    assert add_calls
+    option = add_calls[0].kwargs["json"]["option"]
+    assert option["tag"] == internal_tag
+    assert option["interface"] == ""
+    assert option["force"] == "1"
+    assert option["value"] == "10.0.2.2,10.0.10.46"

--- a/tests/test_dhcp_subnet_dns_kea.py
+++ b/tests/test_dhcp_subnet_dns_kea.py
@@ -1,0 +1,75 @@
+"""Tests for Kea subnet DNS provider methods."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from opnsense_mcp.utils.dhcp_providers.kea import KeaProvider
+
+
+@pytest.fixture
+def make_request() -> AsyncMock:
+    """Create a mock request callable."""
+    return AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_list_subnet_dns_reads_subnet_option_data(make_request: AsyncMock) -> None:
+    subnet_payload = {
+        "uuid": "subnet-v4",
+        "subnet": "10.0.2.0/24",
+        "interface": "opt2",
+        "option_data_autocollect": "1",
+        "option_data": {
+            "domain_name_servers": {"value": "10.0.10.4,10.0.10.5", "selected": 1}
+        },
+    }
+    make_request.side_effect = [
+        {"rows": [{"uuid": "subnet-v4", "subnet": "10.0.2.0/24", "interface": "opt2"}]},
+        {"subnet4": dict(subnet_payload)},
+        {"rows": []},
+    ]
+
+    provider = KeaProvider(make_request)
+    result = await provider.list_subnet_dns(subnet="10.0.2.0/24")
+
+    assert result["backend"] == "kea"
+    assert result["ipv4"] == ["10.0.10.4", "10.0.10.5"]
+    assert result["ipv6"] == []
+
+
+@pytest.mark.asyncio
+async def test_set_subnet_dns_disables_autocollect(make_request: AsyncMock) -> None:
+    subnet_payload = {
+        "uuid": "subnet-v4",
+        "subnet": "10.0.2.0/24",
+        "interface": "opt2",
+        "option_data_autocollect": "1",
+        "option_data": {
+            "domain_name_servers": {"value": "10.0.10.5", "selected": 1}
+        },
+    }
+    make_request.side_effect = [
+        {"rows": [{"uuid": "subnet-v4", "subnet": "10.0.2.0/24", "interface": "opt2"}]},
+        {"subnet4": dict(subnet_payload)},
+        {"result": "saved"},
+        {"result": "done"},
+    ]
+
+    provider = KeaProvider(make_request)
+    result = await provider.set_subnet_dns(
+        subnet="10.0.2.0/24",
+        family="ipv4",
+        servers=["10.0.10.4"],
+    )
+
+    assert result["status"] == "success"
+    set_calls = [
+        call
+        for call in make_request.call_args_list
+        if call.args[:2] == ("POST", "/api/kea/dhcpv4/set_subnet/subnet-v4")
+    ]
+    assert set_calls
+    payload = set_calls[0].kwargs["json"]["subnet4"]
+    assert payload["option_data_autocollect"] == "0"
+    assert payload["option_data"]["domain_name_servers"]["value"] == "10.0.10.4"

--- a/tests/test_dhcp_subnet_dns_tools.py
+++ b/tests/test_dhcp_subnet_dns_tools.py
@@ -1,0 +1,75 @@
+"""Tests for DHCP subnet DNS MCP tools."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from opnsense_mcp.tools.dhcp_subnet_dns import (
+    ListDhcpSubnetDnsTool,
+    SetDhcpSubnetDnsTool,
+)
+
+
+@pytest.fixture
+def mock_client() -> AsyncMock:
+    """Create a mock OPNsense client."""
+    client = AsyncMock()
+    client.list_dhcp_subnet_dns = AsyncMock(
+        return_value={
+            "backend": "dnsmasq",
+            "scope": {"interface": "opt2", "subnet": "10.0.2.0/24"},
+            "ipv4": ["10.0.10.5"],
+            "ipv6": [],
+        }
+    )
+    client.set_dhcp_subnet_dns = AsyncMock(
+        return_value={
+            "status": "success",
+            "backend": "dnsmasq",
+            "family": "ipv4",
+            "before": ["10.0.10.5"],
+            "after": ["10.0.10.4"],
+            "applied": True,
+        }
+    )
+    return client
+
+
+@pytest.mark.asyncio
+async def test_list_tool_requires_scope(mock_client: AsyncMock) -> None:
+    tool = ListDhcpSubnetDnsTool(mock_client)
+    result = await tool.execute({})
+    assert result["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_list_tool_returns_servers(mock_client: AsyncMock) -> None:
+    tool = ListDhcpSubnetDnsTool(mock_client)
+    result = await tool.execute({"interface": "opt2"})
+    assert result["status"] == "success"
+    assert result["ipv4"] == ["10.0.10.5"]
+    mock_client.list_dhcp_subnet_dns.assert_awaited_once_with(
+        subnet=None,
+        interface="opt2",
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_tool_calls_client(mock_client: AsyncMock) -> None:
+    tool = SetDhcpSubnetDnsTool(mock_client)
+    result = await tool.execute(
+        {
+            "interface": "opt2",
+            "family": "ipv4",
+            "dns_server": "10.0.10.4",
+        }
+    )
+    assert result["status"] == "success"
+    mock_client.set_dhcp_subnet_dns.assert_awaited_once_with(
+        subnet=None,
+        interface="opt2",
+        family="ipv4",
+        dns_server="10.0.10.4",
+        dns_servers=None,
+        slot=None,
+    )


### PR DESCRIPTION
## Summary
- Add `list_dhcp_subnet_dns` and `set_dhcp_subnet_dns` MCP tools to read and update per-subnet DHCP DNS servers.
- Support both dnsmasq and Kea backends with automatic provider detection and scoped rollback on failure.
- Fix dnsmasq scoped DNS to resolve DHCP range `set_tag` values so tagged VLAN scopes match OPNsense behavior.

## Test plan
- [x] `uv run pytest tests/test_dhcp_subnet_dns_*.py` (17 tests pass)
- [x] `uv run ruff check .`
- [ ] Verify against live OPNsense with dnsmasq on a tagged VLAN scope


Made with [Cursor](https://cursor.com)