### PR TITLE
feat(dhcp): add host move support for dnsmasq backend

### DIFF
--- a/docs/research/dhcp-host-move-feasibility.md
+++ b/docs/research/dhcp-host-move-feasibility.md
@@ -1,6 +1,6 @@
 # DHCP Host Move & Subnet Defrag — Feasibility
 
-Status: feasibility discussion + **Phase 0 spike complete** (live API validated).  
+Status: feasibility discussion + **Phase 0 spike complete** (live API validated).
 Last updated: 2026-06-11.
 
 > **Phase 0 spike results are in [Phase 0 Spike Results](#phase-0-spike-results-2026-06-11) below.**

--- a/docs/research/dhcp-host-move-feasibility.md
+++ b/docs/research/dhcp-host-move-feasibility.md
@@ -1,0 +1,400 @@
+# DHCP Host Move & Subnet Defrag — Feasibility
+
+Status: feasibility discussion + **Phase 0 spike complete** (live API validated).  
+Last updated: 2026-06-11.
+
+> **Phase 0 spike results are in [Phase 0 Spike Results](#phase-0-spike-results-2026-06-11) below.**
+> Net effect on the IPv4 path: *simpler* than first assumed — a host reservation
+> carries both v4 and v6 in one record keyed by MAC, so the config edit is a single
+> `set_host` on one field.
+>
+> **IPv6 caveat (corrected after live lease inspection):** the `::N` reservation is
+> MAC-keyed in *config*, but DHCPv6 *runtime* identity is the **DUID**. It works
+> today only for clients doing stateful DHCPv6 whose DUID embeds the MAC (DUID-LL).
+> Many wifi/IoT clients use SLAAC/privacy addressing and never take the stateful
+> lease, so their `::N` reservation is inert — moving it is a config-only no-op for
+> those devices. IPv6 moves are therefore **device-dependent**, not universally
+> effective. See [IPv6 reality](#ipv6-reality-duid-vs-mac-stateful-vs-slaac).
+
+## Summary
+
+**We cannot move hosts or reshuffle subnet addresses today.** The MCP server can read DHCP leases and perform a few related operations (delete leases on ISC only, manage Unbound DNS overrides, configure per-subnet DHCP DNS). What is needed for host moves and subnet defrag is **static reservation / host configuration** APIs, which are not implemented yet.
+
+The production firewall in use runs **dnsmasq** (leases expose `is_reserved`, interface keys like `opt2` / `opt5`). That backend should be the first implementation target.
+
+---
+
+## Goals
+
+### Stretch: subnet defrag
+
+Natural-language intent such as *"consolidate subnet 10.0.2.0"*:
+
+- Find lowest free addresses in a subnet.
+- Move higher-numbered hosts into those slots for IPv4 and IPv6.
+- Keep DHCP-registered names aligned so hostnames follow the move.
+
+### MVP: single-host move
+
+Natural-language intent such as *"move hostx to address .2"*:
+
+- Move `hostx` on its current subnet to `x.x.x.2` and `::2` respectively.
+- Preserve reservation identity (MAC / DUID) and hostname registration.
+
+---
+
+## What Exists Today
+
+| Capability | MCP tool / code | Notes |
+|------------|-----------------|-------|
+| List / search leases | `dhcp` | IPv4 + IPv6; strips noisy fields including **DUID** |
+| Delete active lease | `dhcp_lease_delete` | **ISC only** — dnsmasq and Kea return "not supported" |
+| Per-subnet DHCP DNS | `list_dhcp_subnet_dns`, `set_dhcp_subnet_dns` | dnsmasq + Kea; uses `dhcp_scope` resolution |
+| Unbound DNS overrides | `dns`, `mkdns`, `rmdns`, `flush_dns` | Separate from DHCP dynamic registration |
+| Backend detection | `detect_dhcp_backend()` | ISC / Kea / dnsmasq |
+| Host resolution helper | `resolve_host_info()` in API client | Correlates ARP, DHCP, DNS — read-only |
+
+### Not implemented
+
+- List / create / update / delete **static DHCP reservations** (dnsmasq hosts, ISC static maps, Kea reservations)
+- Change a host's reserved IPv4 or IPv6 address
+- Subnet occupancy / lowest-free-address logic
+- Coordinated move with DHCP-registered DNS names
+- Subnet defrag orchestration
+
+### Relevant code paths
+
+- Lease tools: `opnsense_mcp/tools/dhcp.py`, `opnsense_mcp/tools/dhcp_lease_delete.py`
+- Provider layer: `opnsense_mcp/utils/dhcp_provider.py`, `opnsense_mcp/utils/dhcp_providers/{isc,dnsmasq,kea}.py`
+- Scope resolution: `opnsense_mcp/utils/dhcp_scope.py` (subnet CIDR, interface, range lookup)
+- Subnet DNS (rollback pattern reference): `opnsense_mcp/utils/dhcp_subnet_dns.py`, `opnsense_mcp/tools/dhcp_subnet_dns.py`
+- DNS overrides: `opnsense_mcp/tools/mkdns.py`, `opnsense_mcp/tools/dns.py`
+- Endpoint research: `docs/research/dhcp-backend-endpoints.md`
+
+---
+
+## Live Environment Observations
+
+Sample lease data from the production firewall:
+
+### `10.0.2.0/24` (VLAN2wired / `opt2`)
+
+Hosts such as `pi5`, `appletv-basement`, `rpi4-0`, `ds`, `hdhomerun01`, `trogdor-en8` all show `is_reserved: ['hwaddr']`. These are **static dnsmasq host entries**, not ephemeral dynamic leases. Moving them requires editing reservation config (`search_host` / `set_host`), not only deleting a lease.
+
+### `10.0.8.0/24` (VLAN81wifi / `opt5`)
+
+Mixed population:
+
+- **Reserved** (examples): `printer` @ `.2`, `bose-familyroom` @ `.3`, `trogdor` @ `.80`
+- **Dynamic only** (examples): `LG_Smart_Laundry2_open` @ `.7`, `trogphone` @ `.13`, many `*` hostnames
+
+A defrag must treat reserved and dynamic clients differently unless dynamic clients are promoted to reservations first.
+
+### IPv6
+
+Searches for these subnets returned **no IPv6 leases** in the sample. IPv6 defrag may be reservation-only or not in active use yet. When it is, matching must use **DUID / client_id**, not MAC alone.
+
+---
+
+## OPNsense APIs Available (Not Yet Wrapped)
+
+### dnsmasq (primary target)
+
+Documented under [Dnsmasq API](https://docs.opnsense.org/development/api/core/dnsmasq.html):
+
+| Operation | Endpoint |
+|-----------|----------|
+| Search hosts / reservations | `GET` / `POST` `/api/dnsmasq/settings/search_host` |
+| Get host | `GET` `/api/dnsmasq/settings/get_host` |
+| Add host | `POST` `/api/dnsmasq/settings/add_host` |
+| Update host | `POST` `/api/dnsmasq/settings/set_host` |
+| Delete host | `POST` `/api/dnsmasq/settings/del_host` |
+| Search ranges (pool bounds) | `GET` / `POST` `/api/dnsmasq/settings/search_range` |
+| Apply changes | `POST` `/api/dnsmasq/service/reconfigure` |
+
+Behavior notes from OPNsense docs:
+
+- Reservations bind MAC and/or client identifier to fixed addresses.
+- Hostname plus range domain drive **dynamic DNS registration** (dhcp-fqdn).
+- Setting domain on a reservation alone does not change dynamic registration; dnsmasq combines host with the domain configured on the matching DHCP range.
+- Lease search exists (`/api/dnsmasq/leases/search`); **no documented lease-delete endpoint**.
+
+### ISC DHCP (legacy)
+
+- Static maps: `dhcpv4` / `dhcpv6` settings APIs (`search_staticmap`, etc.)
+- Lease delete: `POST /api/dhcpv4/leases/del_lease/{ip}` — **already wrapped** and working
+
+### Kea
+
+- Subnet CRUD is partially wrapped (subnet DNS).
+- Host reservation endpoints need live validation on the target OPNsense version.
+- Lease delete is not documented / not wrapped.
+
+---
+
+## MVP: `move_dhcp_host`
+
+### Suggested tool shape
+
+```
+move_dhcp_host(
+  host | mac | hostname,     # identifier
+  ipv4 | ipv4_suffix,        # full address or last-octet (e.g. 2 → .2)
+  ipv6 | ipv6_suffix,        # optional; later phase
+  subnet | interface,        # optional; default infer from current lease
+  dry_run=true,              # strongly recommended default for first use
+  promote_dynamic=false,     # create reservation if host is dynamic-only
+)
+```
+
+### Workflow (dnsmasq)
+
+```mermaid
+flowchart TD
+  A[Resolve host via lease + search_host] --> B{Static reservation?}
+  B -->|yes| C[set_host: new IP, preserve MAC/DUID/hostname]
+  B -->|no| D[add_host reservation OR refuse without promote_dynamic]
+  C --> E[reconfigure dnsmasq]
+  D --> E
+  E --> F[Optional: update Unbound override if one exists]
+  F --> G[Return result; client must DHCP renew]
+```
+
+### Building blocks to add
+
+1. **Provider protocol extension** — `list_hosts`, `get_host`, `set_host`, `add_host` per backend (mirror the subnet DNS provider pattern).
+2. **Lease ↔ reservation correlation** — match on MAC / `client_id`; use `is_reserved` from lease output as a hint.
+3. **Scope math** — reuse `dhcp_scope` + `search_range` for subnet bounds; exclude gateway (typically `.1`).
+4. **Conflict detection** — target IP must not be used by another reservation or active lease.
+5. **DNS name follow-through**
+   - **DHCP registration**: preserve hostname on reservation; dnsmasq updates on client renew/rebind.
+   - **Static Unbound overrides**: search via `dns`; update via new `setHostOverride` wrapper or `mkdns` / `rmdns` pair.
+6. **Apply + rollback** — snapshot before change, restore on failure (same pattern as `set_dhcp_subnet_dns`).
+
+### MVP limitations
+
+| Topic | Limitation |
+|-------|------------|
+| Remote DHCP renew | Firewall can change reservation; **client must renew** (reboot, `dhclient`, etc.) |
+| dnsmasq lease delete | Not available via API; stale lease may linger until expiry or client renews |
+| Dynamic-only hosts | Reliable moves require creating a reservation first |
+| IPv6 | DUID required; `dhcp` tool currently **strips DUID** from output |
+| Unbound `set` | No MCP wrapper for `setHostOverride` today (only add/delete) |
+
+---
+
+## Stretch: Subnet Defrag
+
+Orchestration layer on top of single-host move.
+
+### Algorithm (high level)
+
+1. Resolve subnet → interface → DHCP range(s).
+2. Build occupancy set: reservations + active leases + reserved gateway/network addresses.
+3. Select move candidates per policy (all reserved hosts? only addresses above a threshold? skip `*` hostnames?).
+4. Assign lowest free slots (`.2`, `.3`, … skipping in-use addresses).
+5. Execute moves in **collision-safe order**:
+   - move into temporary staging addresses first, then into final slots; or
+   - process from highest current IP downward into lowest free slots.
+6. Return dry-run plan before apply.
+
+### Extra complexity vs MVP
+
+| Topic | Challenge |
+|-------|-----------|
+| Mixed static / dynamic | Many clients are dynamic-only; defrag may skip them or auto-promote |
+| Name records | DHCP FQDN vs manual Unbound overrides; `*` hostnames do not follow meaningfully |
+| IPv4 / IPv6 pairing | Stable identity (MAC ↔ DUID) across address families |
+| Live traffic | Moving active devices causes brief connectivity loss |
+| Agent UX | Natural language should map to deterministic dry-run + explicit user confirmation |
+
+### Suggested tools
+
+| Tool | Purpose |
+|------|---------|
+| `plan_subnet_defrag` | Read-only: proposed moves, conflicts, skipped hosts |
+| `apply_subnet_defrag` | Execute a previously generated plan (with rollback) |
+
+---
+
+## Recommended Phases
+
+### Phase 0 — API spike (1–2 days)
+
+Against live OPNsense:
+
+- Capture `search_host` / `get_host` / `set_host` request and response payloads.
+- Document fields for IPv4, IPv6, DUID / `client_id`, hostname, domain, tags.
+- Confirm `reconfigure` behavior and DNS registration side effects.
+
+### Phase 1 — MVP (`move_dhcp_host`)
+
+- dnsmasq only
+- `dry_run` default
+- Single host, IPv4 suffix or full address
+- Conflict detection
+- Optional Unbound override update
+
+### Phase 2 — IPv6 + identity
+
+- Stop stripping DUID in `dhcp` lease output (or expose via separate field)
+- DUID-based reservation moves
+- Paired IPv4 + IPv6 move for the same host
+
+### Phase 3 — Subnet defrag
+
+- `plan_subnet_defrag` + `apply_subnet_defrag`
+- Staging strategy for collision-free multi-move
+- Kea / ISC backends if required
+
+### Phase 4 — Agent ergonomics
+
+- Thin mapping so *"consolidate 10.0.2.0"* invokes plan → confirm → apply
+
+---
+
+## Phase 0 Spike Results (2026-06-11)
+
+Validated live against the production firewall (`fw.freeblizz.com`, dnsmasq backend)
+via the OPNsense REST API. Read operations plus a full throwaway CRUD round-trip
+were exercised. **`reconfigure` was deliberately NOT called**, so the test entry
+never reached the running dnsmasq config; it was created and deleted purely in the
+staged config and cleanup was confirmed (`search_host` for the test name returns 0 rows).
+
+### Key finding: one host record holds both IPv4 and IPv6
+
+A reservation's `ip` field is a **comma-separated v4,v6 pair** in a single record:
+
+```json
+{
+  "uuid": "6c20...bdab", "host": "printer", "domain": "", "local": "0",
+  "ip": "10.0.8.2,::2", "cnames": "", "client_id": "",
+  "hwaddr": "c8:a3:e8:dc:1b:b9", "lease_time": "", "ignore": "0",
+  "set_tag": "", "descr": "VLAN81wifi", "comments": "", "aliases": ""
+}
+```
+
+Consequences:
+
+- A move that changes both families is **one `set_host` call editing one field** in the *config* — inherently atomic, no v4/v6 pairing orchestration needed at the config layer.
+- The reservation's IPv6 is a `::N` suffix; dnsmasq expands it to `<vlan-prefix>::N`. In config it is bound to the `hwaddr` (MAC), `client_id` empty on all 57 hosts.
+- **But config-bound-to-MAC ≠ runtime-matched-by-MAC.** See [IPv6 reality](#ipv6-reality-duid-vs-mac-stateful-vs-slaac) — runtime DHCPv6 matching is by DUID, and effectiveness is device-dependent. Whether the `dhcp` tool's DUID stripping matters depends on the move strategy chosen (config-suffix vs DUID-reservation).
+
+### IPv6 reality: DUID vs MAC, stateful vs SLAAC
+
+Inspecting the live lease table (118 leases: 81 v4, 37 v6) corrected the initial assumption:
+
+- v6 leases are **stateful DHCPv6** on the delegated GUA prefix, keyed by
+  `client_id` = **DUID** (e.g. `00:03:00:01:e4:d1:24:52:91:ff`, a DUID-LL embedding
+  the MAC). The `hwaddr` column is dnsmasq *deriving* MAC from the DUID-LL.
+- **The `::N` suffix reservation works — for stateful clients.** Proof on VLAN2wired:
+  `pi5` 10.0.2.2 → `…b502::2`, `appletv-basement` 10.0.2.6 → `…b502::6`,
+  `ds` 10.0.2.19 → `…b502::19`. The v6 suffix tracks the v4 octet exactly.
+- **It is inert for SLAAC/privacy clients.** The VLAN81wifi reserved hosts `printer`
+  (`::2`) and `bose-familyroom` (`::3`) have **only v4 leases** — no v6 lease at all.
+  Wifi/IoT devices that don't take a stateful DHCPv6 lease ignore the reservation.
+- MAC-keyed v6 reservations only resolve because these DUIDs are DUID-LL (MAC
+  embedded). A client with DUID-LLT/DUID-UUID would not be matched by a MAC-only
+  reservation; that case needs a DUID-based reservation (`client_id` field).
+
+**Design implications:**
+
+1. The MVP `move_dhcp_host` should treat the **IPv4 move as the reliable contract**
+   and the IPv6 suffix as **best-effort, device-dependent**. Report per-family
+   effectiveness rather than implying both always apply.
+2. Detect whether the target host currently holds a stateful v6 lease (lease table)
+   and surface "v6 reservation updated but device uses SLAAC/privacy — no effect" when it doesn't.
+3. A future DUID-reservation mode (write `client_id`) is the escape hatch for
+   non-DUID-LL clients, and is the only path if we ever move *dynamic-only* v6 clients.
+4. **Interactive validation still recommended** before trusting v6 moves: pick a known
+   stateful-DHCPv6 device (VLAN2wired class), move its suffix, `reconfigure`, force
+   renew, and confirm the new address binds via DUID.
+
+### Flat host schema (search_host rows / set_host payload)
+
+`uuid`, `host` (hostname), `domain`, `local`, `ip` (`"v4,v6"`), `cnames`,
+`client_id`, `hwaddr` (MAC), `lease_time`, `ignore`, `set_tag`, `descr`,
+`comments`, `aliases`. Production has **57 host reservations**.
+
+`get_host/{uuid}` returns the OPNsense form-model variant where `ip`, `hwaddr`,
+`cnames`, `aliases`, `set_tag` are option maps; `set_tag` enumerates available
+tags (`None` / `guest` / `internal`). For writes, flatten back to the
+comma-separated string form shown above.
+
+### Verified endpoint contracts
+
+| Operation | Call | Response |
+|-----------|------|----------|
+| List/search | `POST search_host` `{"current":1,"rowCount":-1,"searchPhrase":""}` | `{"rows":[…],"total":57}` |
+| Get one | `GET get_host/{uuid}` — **no `Content-Type` header** | `{"host":{…option-map form…}}` |
+| Create | `POST add_host` `{"host":{…flat…}}` | `{"result":"saved","uuid":"…"}` |
+| Update | `POST set_host/{uuid}` `{"host":{…flat…}}` | `{"result":"saved"}` |
+| Delete | `POST del_host/{uuid}` — **body must be `{}`** | `{"result":"deleted"}` |
+| Ranges | `POST search_range` | rows with `start_addr`/`end_addr`/`interface`/`%interface`/`set_tag`/`domain` |
+
+### Quirks to encode in the provider
+
+- **`del_host` requires a JSON body.** `POST del_host/{uuid}` with a
+  `Content-Type: application/json` header but **no body** returns
+  `{"status":400,"message":"Invalid JSON syntax"}`. Send `{}`.
+- **Do not send `Content-Type: application/json` on `GET get_host`** — it makes the
+  server attempt to parse the absent body. Issue GETs without that header.
+- `set_host`/`add_host`/`del_host` only stage config; **`POST service/reconfigure`** is
+  what applies it (same endpoint `set_dhcp_subnet_dns` already uses in production).
+  `reconfigure` timing and DNS-registration side effects still need confirmation
+  during MVP build, but risk is low given the existing precedent.
+
+### Range data confirms occupancy math is straightforward
+
+Each interface exposes a paired v4 + v6 range, e.g. VLAN2wired (`opt2`) v4
+`10.0.2.3–10.0.2.200` and v6 `::2–::ffff`; VLAN81wifi (`opt5`) v4
+`10.0.8.2–10.0.8.240`. Notable: **reservations can sit below the pool start**
+(VLAN2wired's v4 pool begins at `.3`, leaving `.1`/`.2` for gateway/infra), so
+lowest-free logic must treat the range as the dynamic pool and union reservations
++ active leases + gateway separately.
+
+### DNS follow-through (Technitium, per user)
+
+The environment runs a **Technitium DNS server** (`technit-app` on strongpod) in
+addition to dnsmasq's DHCP-FQDN registration. Moving a host's address will leave
+stale forward/reverse records there until refreshed. Per user direction this is
+**acceptable** — a move tool should flush/refresh external DNS (Technitium and/or
+any Pi-hole) as a follow-on step, and the brief window where a client keeps its old
+address until it renews/reboots is also acceptable.
+
+---
+
+## Feasibility Matrix
+
+| Goal | Feasible? | With current code? |
+|------|-----------|-------------------|
+| See who is on a subnet | Yes | `dhcp search=…` |
+| Move one reserved host to `.2` | Yes, with new work | No |
+| Move dynamic-only host reliably | Yes, if we add reservation | No |
+| Full subnet defrag v4 + v6 + DNS | Yes, larger project | No |
+| Works on current firewall (dnsmasq) | APIs exist on OPNsense | MCP does not call them yet |
+
+---
+
+## Existing Assets to Reuse
+
+- **Backend detection** — `detect_dhcp_backend()` in `opnsense_mcp/utils/dhcp_provider.py`
+- **Scope resolution** — `dhcp_scope.py` (subnet CIDR, interface keys, range endpoints)
+- **Rollback pattern** — `dhcp_subnet_dns.py` (snapshot before / restore on failure)
+- **DNS tooling** — `mkdns`, `rmdns`, `flush_dns`, `dns`
+- **Endpoint research** — `docs/research/dhcp-backend-endpoints.md`
+
+The missing core is a **DHCP host / reservation provider** and a **move orchestrator** on top of it.
+
+---
+
+## Next Step
+
+**Phase 0 is done** (see [Phase 0 Spike Results](#phase-0-spike-results-2026-06-11)).
+The dnsmasq host API is fully characterized and CRUD is validated live.
+
+Proceed to drafting the **Phase 1 implementation plan** for `move_dhcp_host`:
+
+- Extend the DHCP provider protocol with `list_hosts` / `get_host` / `add_host` / `set_host` / `del_host` (dnsmasq first), encoding the `del_host` empty-body and GET no-`Content-Type` quirks.
+- Move orchestrator: resolve host → read record → rewrite `ip` (v4 and/or v6 suffix) → conflict-check against reservations + active leases + range/gateway → `set_host` → `reconfigure`, with snapshot/rollback mirroring `set_subnet_dns`.
+- `dry_run` default; optional external DNS (Technitium) refresh as a follow-on.

--- a/docs/research/dhcp-host-move-feasibility.md
+++ b/docs/research/dhcp-host-move-feasibility.md
@@ -293,9 +293,33 @@ Inspecting the live lease table (118 leases: 81 v4, 37 v6) corrected the initial
 - **It is inert for SLAAC/privacy clients.** The VLAN81wifi reserved hosts `printer`
   (`::2`) and `bose-familyroom` (`::3`) have **only v4 leases** — no v6 lease at all.
   Wifi/IoT devices that don't take a stateful DHCPv6 lease ignore the reservation.
-- MAC-keyed v6 reservations only resolve because these DUIDs are DUID-LL (MAC
-  embedded). A client with DUID-LLT/DUID-UUID would not be matched by a MAC-only
-  reservation; that case needs a DUID-based reservation (`client_id` field).
+- MAC-keyed v6 reservations resolve whenever the client's DUID **contains the
+  link-layer address** — both **DUID-LL** (type 3) and **DUID-LLT** (type 1, observed
+  on the Apple TVs and macOS) embed the MAC, so dnsmasq matches both. Only a
+  **DUID-UUID** (type 4) client would fail a MAC-only reservation and need a
+  `client_id`-based reservation. None were observed in this environment.
+
+#### Live move test — empirical proof (2026-06-11)
+
+Ran an actual create-reservation + renew cycle on a user-controlled MacBook Pro
+(`50:f2:65:e9:7c:b0`, dynamic at `10.0.8.133`), targeting `10.0.8.96,::96`:
+
+| Family | Before | After reservation + DHCP renew | Verdict |
+|--------|--------|-------------------------------|---------|
+| IPv4 | `10.0.8.133` (dynamic) | **`10.0.8.96`**, `is_reserved=['hwaddr']` | reservation honored |
+| IPv6 | `…b508::ce3a` (SLAAC privacy) | **still `…b508::ce3a`** | reservation **inert** |
+
+The v6 lease flipped to `is_reserved=['hwaddr']` (dnsmasq knows the reservation
+exists) yet the device stayed on its SLAAC **privacy** address — macOS never sent a
+stateful DHCPv6 address request, so `::96` was never assigned. This confirms on real
+hardware: **IPv4 reservation moves are reliable; IPv6 `::N` moves are a config-only
+no-op for SLAAC/privacy clients (macOS), effective only for stateful-DHCPv6 devices
+(Apple TV, Synology observed).** Also validated live: `add_host` promotes a
+dynamic host to a reservation, and `reconfigure` returns `{"status":"ok"}` quickly.
+Cleanup via `del_host` (`{}` body) confirmed.
+
+**`move_dhcp_host` MUST therefore classify and report IPv6 effect** (applied /
+pending-renew / inert-SLAAC) rather than implying the v6 change took effect.
 
 **Design implications:**
 

--- a/opnsense_mcp/server.py
+++ b/opnsense_mcp/server.py
@@ -84,6 +84,7 @@ from opnsense_mcp.build_info import get_build_info
 from opnsense_mcp.tools.aliases import AliasesTool
 from opnsense_mcp.tools.arp import ARPTool
 from opnsense_mcp.tools.dhcp import DHCPTool
+from opnsense_mcp.tools.dhcp_host_move import MoveDhcpHostTool
 from opnsense_mcp.tools.dhcp_lease_delete import DHCPLeaseDeleteTool
 from opnsense_mcp.tools.dhcp_subnet_dns import (
     ListDhcpSubnetDnsTool,
@@ -197,6 +198,7 @@ async def handle_message(
     dhcp_lease_delete_tool: DHCPLeaseDeleteTool,
     list_dhcp_subnet_dns_tool: ListDhcpSubnetDnsTool,
     set_dhcp_subnet_dns_tool: SetDhcpSubnetDnsTool,
+    move_dhcp_host_tool: MoveDhcpHostTool,
     lldp_tool: LLDPTool,
     system_tool: SystemTool,
     fw_rules_tool: FwRulesTool,
@@ -352,6 +354,11 @@ async def handle_message(
                 "name": "set_dhcp_subnet_dns",
                 "description": SetDhcpSubnetDnsTool.description,
                 "inputSchema": SetDhcpSubnetDnsTool.input_schema,
+            },
+            {
+                "name": MoveDhcpHostTool.name,
+                "description": MoveDhcpHostTool.description,
+                "inputSchema": MoveDhcpHostTool.input_schema,
             },
             {
                 "name": "lldp",
@@ -864,6 +871,13 @@ async def handle_message(
                 "id": msg_id,
                 "result": {"content": [{"type": "text", "text": str(result)}]},
             }
+        if tool_name == "move_dhcp_host":
+            result = await move_dhcp_host_tool.execute(arguments)
+            return {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {"content": [{"type": "text", "text": str(result)}]},
+            }
         if tool_name == "get_logs":
             logs = await firewall_logs.get_logs(
                 limit=arguments.get("limit", 500),
@@ -1072,6 +1086,7 @@ def main() -> None:
     dhcp_lease_delete_tool = DHCPLeaseDeleteTool(client)
     list_dhcp_subnet_dns_tool = ListDhcpSubnetDnsTool(client)
     set_dhcp_subnet_dns_tool = SetDhcpSubnetDnsTool(client)
+    move_dhcp_host_tool = MoveDhcpHostTool(client)
     lldp_tool = LLDPTool(client)
     system_tool = SystemTool(client)
     fw_rules_tool = FwRulesTool(client)
@@ -1138,6 +1153,7 @@ def main() -> None:
                     dhcp_lease_delete_tool,
                     list_dhcp_subnet_dns_tool,
                     set_dhcp_subnet_dns_tool,
+                    move_dhcp_host_tool,
                     lldp_tool,
                     system_tool,
                     fw_rules_tool,

--- a/opnsense_mcp/tools/dhcp_host_move.py
+++ b/opnsense_mcp/tools/dhcp_host_move.py
@@ -1,0 +1,77 @@
+"""MCP tool to move a DHCP host reservation to a new address."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from opnsense_mcp.utils.api import OPNsenseClient
+
+logger = logging.getLogger(__name__)
+
+
+class MoveDhcpHostTool:
+    """Move a dnsmasq host reservation to a new IPv4 and/or IPv6 address."""
+
+    name = "move_dhcp_host"
+    description = (
+        "Move a DHCP host reservation (dnsmasq) to a new IPv4 and/or IPv6 address. "
+        "IPv4 is the reliable contract; IPv6 (::N suffix) applies only to "
+        "stateful-DHCPv6 clients. Defaults to a dry run; pass apply=true to write. "
+        "The client keeps its old address until it renews or reboots."
+    )
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "host": {
+                "type": "string",
+                "description": "Hostname or MAC of the reservation to move",
+            },
+            "ipv4": {
+                "type": ["integer", "string"],
+                "description": "New IPv4: last octet (e.g. 2) or full address",
+            },
+            "ipv6": {
+                "type": ["integer", "string"],
+                "description": "New IPv6 suffix: e.g. 2 -> ::2, or '::abcd'",
+            },
+            "apply": {
+                "type": "boolean",
+                "description": "Apply the change. Omit/false = dry run.",
+            },
+        },
+        "required": ["host"],
+        "anyOf": [{"required": ["ipv4"]}, {"required": ["ipv6"]}],
+    }
+
+    def __init__(self, client: OPNsenseClient | None) -> None:
+        """Initialize the tool."""
+        self.client = client
+
+    async def execute(self, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Validate args and delegate the move to the client."""
+        params = params or {}
+        if not self.client:
+            return {"status": "error", "error": "No client available"}
+
+        identifier = str(params.get("host") or "").strip()
+        if not identifier:
+            return {"status": "error", "error": "host (hostname or MAC) is required"}
+
+        ipv4 = params.get("ipv4")
+        ipv6 = params.get("ipv6")
+        if ipv4 is None and ipv6 is None:
+            return {"status": "error", "error": "Provide ipv4 and/or ipv6 target"}
+
+        apply = bool(params.get("apply", False))
+        try:
+            return await self.client.move_dhcp_host(
+                identifier=identifier,
+                ipv4=ipv4,
+                ipv6=ipv6,
+                dry_run=not apply,
+            )
+        except Exception as exc:
+            logger.exception("Failed to move DHCP host")
+            return {"status": "error", "error": str(exc)}

--- a/opnsense_mcp/tools/dhcp_subnet_dns.py
+++ b/opnsense_mcp/tools/dhcp_subnet_dns.py
@@ -122,7 +122,9 @@ class SetDhcpSubnetDnsTool:
         raw_servers = params.get("dns_servers")
         dns_servers: list[str] | None = None
         if isinstance(raw_servers, list):
-            dns_servers = [str(item).strip() for item in raw_servers if str(item).strip()]
+            dns_servers = [
+                str(item).strip() for item in raw_servers if str(item).strip()
+            ]
         slot_raw = params.get("slot")
         slot = int(slot_raw) if slot_raw is not None else None
 

--- a/opnsense_mcp/utils/api.py
+++ b/opnsense_mcp/utils/api.py
@@ -19,6 +19,7 @@ from urllib3.exceptions import InsecureRequestWarning
 from opnsense_mcp.utils.dhcp_provider import (
     DHCPProvider,
     detect_dhcp_backend,
+    require_host_provider,
     require_subnet_dns_provider,
 )
 from opnsense_mcp.utils.dhcp_subnet_dns import Family, merge_slot_update
@@ -906,6 +907,26 @@ class OPNsenseClient:
             interface=interface,
             family=normalized_family,
             servers=merged,
+        )
+
+    async def move_dhcp_host(
+        self,
+        *,
+        identifier: str,
+        ipv4: int | str | None = None,
+        ipv6: int | str | None = None,
+        dry_run: bool = True,
+    ) -> dict[str, Any]:
+        """Move a DHCP host reservation to new v4/v6 addresses (dnsmasq only)."""
+        await self._ensure_dhcp_provider()
+        if self._dhcp_provider is None:
+            raise RuntimeError("DHCP provider not initialized")
+        provider = require_host_provider(self._dhcp_provider)
+        return await provider.move_host(
+            identifier=identifier,
+            ipv4_target=ipv4,
+            ipv6_target=ipv6,
+            dry_run=dry_run,
         )
 
     async def get_firewall_logs(

--- a/opnsense_mcp/utils/dhcp_host.py
+++ b/opnsense_mcp/utils/dhcp_host.py
@@ -123,3 +123,41 @@ def flatten_host_for_write(
     }
     payload["ip"] = format_ip_field(new_ipv4, new_ipv6)
     return payload
+
+
+def find_ipv4_conflicts(
+    *,
+    target_ipv4: str,
+    moving_uuid: str,
+    hosts: list[dict[str, Any]],
+    leases: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return conflicts for ``target_ipv4``: other reservations or active leases
+    already holding the address. The host being moved (``moving_uuid``) is ignored.
+    """
+    conflicts: list[dict[str, Any]] = []
+    for row in hosts:
+        if str(row.get("uuid") or "") == moving_uuid:
+            continue
+        v4, _ = parse_ip_field(str(row.get("ip") or ""))
+        if v4 == target_ipv4:
+            conflicts.append(
+                {
+                    "kind": "reservation",
+                    "host": str(row.get("host") or ""),
+                    "address": target_ipv4,
+                    "hwaddr": str(row.get("hwaddr") or ""),
+                }
+            )
+    for lease in leases:
+        addr = str(lease.get("address") or lease.get("ip") or "")
+        if addr == target_ipv4:
+            conflicts.append(
+                {
+                    "kind": "lease",
+                    "address": target_ipv4,
+                    "hostname": str(lease.get("hostname") or ""),
+                    "hwaddr": str(lease.get("hwaddr") or ""),
+                }
+            )
+    return conflicts

--- a/opnsense_mcp/utils/dhcp_host.py
+++ b/opnsense_mcp/utils/dhcp_host.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import ipaddress  # noqa: F401 # used by later helpers
+import ipaddress
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -71,3 +71,39 @@ class DhcpHostRecord:
             hwaddr=str(row.get("hwaddr") or "").lower(),
             raw=dict(row),
         )
+
+
+def apply_v4_suffix(current_ipv4: str, target: int | str) -> str:
+    """Return a new IPv4 address: replace the last octet (int target) or
+    validate a full address (str target) within the current /24-style network.
+    """
+    base = ipaddress.ip_address(current_ipv4.strip())
+    if base.version != 4:
+        msg = f"Not an IPv4 address: {current_ipv4!r}"
+        raise ValueError(msg)
+    if isinstance(target, int) or str(target).isdigit():
+        octet = int(target)
+        if not 1 <= octet <= 254:
+            msg = f"IPv4 host octet out of range (1-254): {octet}"
+            raise ValueError(msg)
+        prefix = ".".join(current_ipv4.split(".")[:3])
+        return f"{prefix}.{octet}"
+    candidate = ipaddress.ip_address(str(target).strip())
+    if candidate.version != 4:
+        msg = f"Expected IPv4 address, got {target!r}"
+        raise ValueError(msg)
+    return str(candidate)
+
+
+def apply_v6_suffix(target: int | str) -> str:
+    """Return a normalized '::N' IPv6 suffix from an int or string form."""
+    if isinstance(target, int) or str(target).isdigit():
+        return f"::{int(target):x}"
+    raw = str(target).strip()
+    if raw.startswith("::0x"):
+        return f"::{int(raw[4:], 16):x}"
+    ipaddress.ip_address(raw)
+    if not raw.startswith("::"):
+        msg = f"IPv6 reservation must be a '::N' suffix, got {raw!r}"
+        raise ValueError(msg)
+    return raw

--- a/opnsense_mcp/utils/dhcp_host.py
+++ b/opnsense_mcp/utils/dhcp_host.py
@@ -107,3 +107,19 @@ def apply_v6_suffix(target: int | str) -> str:
         msg = f"IPv6 reservation must be a '::N' suffix, got {raw!r}"
         raise ValueError(msg)
     return raw
+
+
+def flatten_host_for_write(
+    record: DhcpHostRecord,
+    *,
+    new_ipv4: str | None,
+    new_ipv6: str | None,
+) -> dict[str, Any]:
+    """Build a flat host payload (inner object for ``{"host": ...}``) preserving
+    all original fields and replacing only the ``ip`` field.
+    """
+    payload: dict[str, Any] = {
+        key: str(record.raw.get(key, "") or "") for key in _PASSTHROUGH_FIELDS
+    }
+    payload["ip"] = format_ip_field(new_ipv4, new_ipv6)
+    return payload

--- a/opnsense_mcp/utils/dhcp_host.py
+++ b/opnsense_mcp/utils/dhcp_host.py
@@ -1,0 +1,73 @@
+"""Pure helpers for DHCP host (reservation) records — no I/O."""
+
+from __future__ import annotations
+
+import ipaddress  # noqa: F401 # used by later helpers
+from dataclasses import dataclass, field
+from typing import Any
+
+# Fields preserved verbatim when rewriting a host record back to the API.
+_PASSTHROUGH_FIELDS = (
+    "host",
+    "domain",
+    "local",
+    "cnames",
+    "client_id",
+    "hwaddr",
+    "lease_time",
+    "ignore",
+    "set_tag",
+    "descr",
+    "comments",
+    "aliases",
+)
+
+
+def parse_ip_field(raw: str) -> tuple[str | None, str | None]:
+    """Split a dnsmasq host ``ip`` field into (ipv4, ipv6) parts.
+
+    The field is a comma-joined list; entries containing ':' are IPv6
+    (including bare suffixes like '::2'), everything else IPv4.
+    """
+    ipv4: str | None = None
+    ipv6: str | None = None
+    for token in str(raw or "").split(","):
+        part = token.strip()
+        if not part:
+            continue
+        if ":" in part:
+            ipv6 = part
+        else:
+            ipv4 = part
+    return ipv4, ipv6
+
+
+def format_ip_field(ipv4: str | None, ipv6: str | None) -> str:
+    """Join (ipv4, ipv6) back into a dnsmasq ``ip`` field, v4 first."""
+    parts = [p for p in (ipv4, ipv6) if p]
+    return ",".join(parts)
+
+
+@dataclass
+class DhcpHostRecord:
+    """A dnsmasq host reservation, decomposed for editing."""
+
+    uuid: str
+    host: str
+    ipv4: str | None
+    ipv6_suffix: str | None
+    hwaddr: str
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_row(cls, row: dict[str, Any]) -> DhcpHostRecord:
+        """Build a record from a ``search_host`` row."""
+        ipv4, ipv6 = parse_ip_field(str(row.get("ip") or ""))
+        return cls(
+            uuid=str(row.get("uuid") or ""),
+            host=str(row.get("host") or ""),
+            ipv4=ipv4,
+            ipv6_suffix=ipv6,
+            hwaddr=str(row.get("hwaddr") or "").lower(),
+            raw=dict(row),
+        )

--- a/opnsense_mcp/utils/dhcp_provider.py
+++ b/opnsense_mcp/utils/dhcp_provider.py
@@ -48,9 +48,21 @@ def require_subnet_dns_provider(provider: DHCPProvider) -> Any:
     """Return provider when subnet DNS is supported, else raise ValueError."""
     if not provider_supports_subnet_dns(provider):
         backend = getattr(provider, "name", provider.__class__.__name__)
-        msg = (
-            f"Subnet DNS configuration is not supported for DHCP backend {backend!r}"
-        )
+        msg = f"Subnet DNS configuration is not supported for DHCP backend {backend!r}"
+        raise ValueError(msg)
+    return provider
+
+
+def provider_supports_host_move(provider: DHCPProvider) -> bool:
+    """Return True when the detected provider supports host moves."""
+    return bool(getattr(provider, "HOST_MOVE_SUPPORTED", False))
+
+
+def require_host_provider(provider: DHCPProvider) -> Any:
+    """Return provider when host move is supported, else raise ValueError."""
+    if not provider_supports_host_move(provider):
+        backend = getattr(provider, "name", provider.__class__.__name__)
+        msg = f"DHCP host move is not supported for backend {backend!r}"
         raise ValueError(msg)
     return provider
 

--- a/opnsense_mcp/utils/dhcp_providers/dnsmasq.py
+++ b/opnsense_mcp/utils/dhcp_providers/dnsmasq.py
@@ -481,17 +481,29 @@ class DnsmasqProvider:
         return response if isinstance(response, dict) else {}
 
     async def _find_host(self, identifier: str) -> dict[str, Any] | None:
-        """Find a single host row by hostname or MAC."""
+        """Find a single host row by hostname or MAC.
+
+        If multiple rows share the same MAC or hostname, the first match in the
+        returned order is used.
+        """
         needle = identifier.strip().lower()
-        rows = await self.list_hosts(search=identifier)
-        if not rows:
-            rows = await self.list_hosts()
-        for row in rows:
-            if str(row.get("host") or "").lower() == needle:
-                return row
-            if str(row.get("hwaddr") or "").lower() == needle:
-                return row
-        return None
+
+        def _match(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
+            for row in rows:
+                if str(row.get("host") or "").lower() == needle:
+                    return row
+                if str(row.get("hwaddr") or "").lower() == needle:
+                    return row
+            return None
+
+        # OPNsense server-side search is fuzzy and may return rows that match the
+        # identifier in some other field (e.g. description) but not by host/MAC.
+        # Try the filtered result first, then fall back to the full list if the
+        # exact-match scan finds nothing.
+        match = _match(await self.list_hosts(search=identifier))
+        if match is not None:
+            return match
+        return _match(await self.list_hosts())
 
     async def move_host(
         self,
@@ -521,6 +533,13 @@ class DnsmasqProvider:
             new_ipv4 = apply_v4_suffix(rec.ipv4, ipv4_target)
         if ipv6_target is not None:
             new_ipv6 = apply_v6_suffix(ipv6_target)
+
+        if new_ipv4 == rec.ipv4 and new_ipv6 == rec.ipv6_suffix:
+            return {
+                "status": "noop",
+                "backend": self.name,
+                "note": "No address changes requested.",
+            }
 
         all_hosts = await self.list_hosts()
         leases = self._extract_leases(

--- a/opnsense_mcp/utils/dhcp_providers/dnsmasq.py
+++ b/opnsense_mcp/utils/dhcp_providers/dnsmasq.py
@@ -4,6 +4,13 @@ import logging
 from collections.abc import Callable, Coroutine
 from typing import Any
 
+from opnsense_mcp.utils.dhcp_host import (
+    DhcpHostRecord,
+    apply_v4_suffix,
+    apply_v6_suffix,
+    find_ipv4_conflicts,
+    flatten_host_for_write,
+)
 from opnsense_mcp.utils.dhcp_scope import resolve_scope_from_selectors
 from opnsense_mcp.utils.dhcp_subnet_dns import (
     DhcpScope,
@@ -472,3 +479,124 @@ class DnsmasqProvider:
             timeout=self.WRITE_TIMEOUT_SECONDS,
         )
         return response if isinstance(response, dict) else {}
+
+    async def _find_host(self, identifier: str) -> dict[str, Any] | None:
+        """Find a single host row by hostname or MAC."""
+        needle = identifier.strip().lower()
+        rows = await self.list_hosts(search=identifier)
+        if not rows:
+            rows = await self.list_hosts()
+        for row in rows:
+            if str(row.get("host") or "").lower() == needle:
+                return row
+            if str(row.get("hwaddr") or "").lower() == needle:
+                return row
+        return None
+
+    async def move_host(
+        self,
+        *,
+        identifier: str,
+        ipv4_target: int | str | None,
+        ipv6_target: int | str | None,
+        dry_run: bool = True,
+    ) -> dict[str, Any]:
+        """Move a host reservation to new v4 and/or v6 addresses."""
+        row = await self._find_host(identifier)
+        if row is None:
+            return {
+                "status": "error",
+                "error": f"No host reservation matched {identifier!r}",
+            }
+        rec = DhcpHostRecord.from_row(row)
+
+        new_ipv4 = rec.ipv4
+        new_ipv6 = rec.ipv6_suffix
+        if ipv4_target is not None:
+            if not rec.ipv4:
+                return {
+                    "status": "error",
+                    "error": f"{rec.host} has no IPv4 reservation to move",
+                }
+            new_ipv4 = apply_v4_suffix(rec.ipv4, ipv4_target)
+        if ipv6_target is not None:
+            new_ipv6 = apply_v6_suffix(ipv6_target)
+
+        all_hosts = await self.list_hosts()
+        leases = self._extract_leases(
+            await self._request(
+                "POST",
+                self.LEASE_ENDPOINT,
+                json={"current": 1, "rowCount": -1, "searchPhrase": ""},
+            )
+        )
+        conflicts: list[dict[str, Any]] = []
+        if new_ipv4 and new_ipv4 != rec.ipv4:
+            conflicts = find_ipv4_conflicts(
+                target_ipv4=new_ipv4,
+                moving_uuid=rec.uuid,
+                hosts=all_hosts,
+                leases=leases,
+            )
+
+        planned = {
+            "host": rec.host,
+            "hwaddr": rec.hwaddr,
+            "ipv4": {"from": rec.ipv4, "to": new_ipv4}
+            if new_ipv4 != rec.ipv4
+            else None,
+            "ipv6": {"from": rec.ipv6_suffix, "to": new_ipv6}
+            if new_ipv6 != rec.ipv6_suffix
+            else None,
+        }
+
+        if conflicts:
+            return {
+                "status": "error",
+                "backend": self.name,
+                "planned": planned,
+                "conflicts": conflicts,
+            }
+
+        if dry_run:
+            return {
+                "status": "dry_run",
+                "backend": self.name,
+                "planned": planned,
+                "note": "No changes applied. Re-run with dry_run=false to apply.",
+            }
+
+        original_payload = flatten_host_for_write(
+            rec, new_ipv4=rec.ipv4, new_ipv6=rec.ipv6_suffix
+        )
+        new_payload = flatten_host_for_write(rec, new_ipv4=new_ipv4, new_ipv6=new_ipv6)
+        try:
+            await self.set_host(rec.uuid, new_payload)
+            await self._reconfigure()
+        except Exception as exc:
+            logger.exception("host move failed; rolling back")
+            restore_error: str | None = None
+            try:
+                await self.set_host(rec.uuid, original_payload)
+                await self._reconfigure()
+            except Exception as restore_exc:
+                restore_error = str(restore_exc)
+                logger.exception("host move rollback failed")
+            return {
+                "status": "error",
+                "backend": self.name,
+                "planned": planned,
+                "error": str(exc),
+                "restored": restore_error is None,
+                "restore_error": restore_error,
+            }
+
+        return {
+            "status": "success",
+            "backend": self.name,
+            "planned": planned,
+            "renewal_note": (
+                "Reservation updated. Client keeps its old address until it "
+                "renews or reboots. IPv6 applies only to stateful-DHCPv6 clients."
+            ),
+        }

--- a/opnsense_mcp/utils/dhcp_providers/dnsmasq.py
+++ b/opnsense_mcp/utils/dhcp_providers/dnsmasq.py
@@ -37,6 +37,12 @@ class DnsmasqProvider:
     WRITE_TIMEOUT_SECONDS = 30
     RECONFIGURE_TIMEOUT_SECONDS = 60
     SUBNET_DNS_SUPPORTED = True
+    HOST_SEARCH_ENDPOINT = "/api/dnsmasq/settings/search_host"
+    HOST_GET_ENDPOINT = "/api/dnsmasq/settings/get_host"
+    HOST_ADD_ENDPOINT = "/api/dnsmasq/settings/add_host"
+    HOST_SET_ENDPOINT = "/api/dnsmasq/settings/set_host"
+    HOST_DEL_ENDPOINT = "/api/dnsmasq/settings/del_host"
+    HOST_MOVE_SUPPORTED = True
 
     def __init__(self, make_request: MakeRequestFn) -> None:
         """Initialize provider with request function."""
@@ -422,3 +428,47 @@ class DnsmasqProvider:
                 "DHCP clients keep prior DNS until they renew or reconnect"
             ),
         }
+
+    async def list_hosts(self, search: str = "") -> list[dict[str, Any]]:
+        """Return host reservation rows (optionally filtered by searchPhrase)."""
+        response = await self._request(
+            "POST",
+            self.HOST_SEARCH_ENDPOINT,
+            json={"current": 1, "rowCount": -1, "searchPhrase": search},
+        )
+        return extract_rows(response)
+
+    async def get_host(self, uuid: str) -> dict[str, Any]:
+        """Return the form-model host record for a uuid (GET, no body)."""
+        response = await self._request("GET", f"{self.HOST_GET_ENDPOINT}/{uuid}")
+        return response if isinstance(response, dict) else {}
+
+    async def add_host(self, host_payload: dict[str, Any]) -> dict[str, Any]:
+        """Create a host reservation; returns {'result','uuid'}."""
+        response = await self._request(
+            "POST",
+            self.HOST_ADD_ENDPOINT,
+            json={"host": host_payload},
+            timeout=self.WRITE_TIMEOUT_SECONDS,
+        )
+        return response if isinstance(response, dict) else {}
+
+    async def set_host(self, uuid: str, host_payload: dict[str, Any]) -> dict[str, Any]:
+        """Update a host reservation by uuid."""
+        response = await self._request(
+            "POST",
+            f"{self.HOST_SET_ENDPOINT}/{uuid}",
+            json={"host": host_payload},
+            timeout=self.WRITE_TIMEOUT_SECONDS,
+        )
+        return response if isinstance(response, dict) else {}
+
+    async def del_host(self, uuid: str) -> dict[str, Any]:
+        """Delete a host reservation by uuid. Empty JSON body is required."""
+        response = await self._request(
+            "POST",
+            f"{self.HOST_DEL_ENDPOINT}/{uuid}",
+            json={},
+            timeout=self.WRITE_TIMEOUT_SECONDS,
+        )
+        return response if isinstance(response, dict) else {}

--- a/opnsense_mcp/utils/dhcp_providers/isc.py
+++ b/opnsense_mcp/utils/dhcp_providers/isc.py
@@ -18,6 +18,7 @@ class ISCProvider:
     V4_DELETE_ENDPOINT = "/api/dhcpv4/leases/del_lease"
     V6_DELETE_ENDPOINT = "/api/dhcpv6/leases/del_lease"
     SERVICE_STATUS_ENDPOINT_V4 = "/api/dhcpv4/service/status"
+    HOST_MOVE_SUPPORTED = False
 
     def __init__(self, make_request: MakeRequestFn) -> None:
         """Initialize provider with request function."""
@@ -98,3 +99,17 @@ class ISCProvider:
         except Exception as exc:
             logger.exception("ISC: failed to delete DHCPv6 lease %s", ip)
             return {"status": "error", "error": str(exc)}
+
+    async def move_host(
+        self,
+        *,
+        identifier: str,
+        ipv4_target: int | str | None,
+        ipv6_target: int | str | None,
+        dry_run: bool = True,
+    ) -> dict[str, Any]:
+        """Host move is not supported on this backend yet."""
+        return {
+            "status": "error",
+            "error": f"Host move not supported by {self.name} backend",
+        }

--- a/opnsense_mcp/utils/dhcp_providers/kea.py
+++ b/opnsense_mcp/utils/dhcp_providers/kea.py
@@ -33,6 +33,7 @@ class KeaProvider:
     V6_SUBNET_SET_ENDPOINT = "/api/kea/dhcpv6/set_subnet"
     RECONFIGURE_ENDPOINT = "/api/kea/service/reconfigure"
     SUBNET_DNS_SUPPORTED = True
+    HOST_MOVE_SUPPORTED = False
 
     def __init__(self, make_request: MakeRequestFn) -> None:
         """Initialize provider with request function."""
@@ -334,4 +335,18 @@ class KeaProvider:
             "renewal_note": (
                 "DHCP clients keep prior DNS until they renew or reconnect"
             ),
+        }
+
+    async def move_host(
+        self,
+        *,
+        identifier: str,
+        ipv4_target: int | str | None,
+        ipv6_target: int | str | None,
+        dry_run: bool = True,
+    ) -> dict[str, Any]:
+        """Host move is not supported on this backend yet."""
+        return {
+            "status": "error",
+            "error": f"Host move not supported by {self.name} backend",
         }

--- a/opnsense_mcp/utils/dhcp_scope.py
+++ b/opnsense_mcp/utils/dhcp_scope.py
@@ -147,7 +147,9 @@ async def resolve_scope_from_selectors(
             description=str(description) if description else None,
         )
 
-    assert normalized_subnet is not None
+    if normalized_subnet is None:
+        msg = "subnet selector is required when interface is not provided"
+        raise ValueError(msg)
     response = await make_request("GET", range_search_endpoint)
     rows = extract_rows(response)
     for row in rows:
@@ -229,7 +231,9 @@ async def resolve_kea_scope(
         msg = f"No Kea {family} subnet found for {normalized_subnet}"
         raise ValueError(msg)
 
-    assert resolved_interface is not None
+    if resolved_interface is None:
+        msg = "interface selector is required when subnet is not provided"
+        raise ValueError(msg)
     if not overview:
         overview = await load_interface_overview(make_request)
     iface_subnet = interface_ipv4_network(resolved_interface, overview)

--- a/opnsense_mcp/utils/dhcp_subnet_dns.py
+++ b/opnsense_mcp/utils/dhcp_subnet_dns.py
@@ -135,7 +135,9 @@ def merge_slot_update(
         else:
             slots[0], slots[1] = validated[0], validated[1]
     else:
-        assert dns_server is not None
+        if dns_server is None:
+            msg = "dns_server or dns_servers is required"
+            raise ValueError(msg)
         validated_one = validate_address(dns_server, family)
         target = slot or 1
         if target not in (1, 2):

--- a/tests/test_bandit.py
+++ b/tests/test_bandit.py
@@ -4,6 +4,15 @@ import json
 import subprocess
 
 
+def _load_bandit_report(stdout: str) -> dict:
+    """Parse Bandit JSON output, ignoring optional progress-bar prefix lines."""
+    start = stdout.find("{")
+    if start == -1:
+        msg = f"Bandit produced no JSON output:\n{stdout}"
+        raise AssertionError(msg)
+    return json.loads(stdout[start:])
+
+
 def test_bandit_clean():
     """Run Bandit and assert zero findings (nosec-suppressed lines are excluded)."""
     result = subprocess.run(
@@ -15,6 +24,7 @@ def test_bandit_clean():
             "opnsense_mcp/",
             "-f",
             "json",
+            "-q",
             "-c",
             "pyproject.toml",
         ],
@@ -24,7 +34,7 @@ def test_bandit_clean():
     if result.returncode == 0:
         return  # No issues found
 
-    report = json.loads(result.stdout)
+    report = _load_bandit_report(result.stdout)
     results = report.get("results", [])
     if results:
         messages = []

--- a/tests/test_dhcp_host.py
+++ b/tests/test_dhcp_host.py
@@ -4,6 +4,7 @@ from opnsense_mcp.utils.dhcp_host import (
     DhcpHostRecord,
     apply_v4_suffix,
     apply_v6_suffix,
+    find_ipv4_conflicts,
     flatten_host_for_write,
     format_ip_field,
     parse_ip_field,
@@ -106,3 +107,43 @@ def test_flatten_host_for_write_changes_ip_only():
     assert payload["set_tag"] == "t1"
     assert payload["descr"] == "x"
     assert payload["hwaddr"] == "AA:BB"
+
+
+def test_find_ipv4_conflicts_other_reservation():
+    hosts = [
+        {"uuid": "u1", "host": "printer", "ip": "10.0.8.2,::2", "hwaddr": "AA"},
+        {"uuid": "u2", "host": "bose", "ip": "10.0.8.9,::9", "hwaddr": "BB"},
+    ]
+    leases = [{"address": "10.0.8.50", "hwaddr": "CC", "hostname": "tv"}]
+    conflicts = find_ipv4_conflicts(
+        target_ipv4="10.0.8.9",
+        moving_uuid="u1",
+        hosts=hosts,
+        leases=leases,
+    )
+    assert any(c["kind"] == "reservation" and c["host"] == "bose" for c in conflicts)
+
+
+def test_find_ipv4_conflicts_active_lease():
+    hosts = [{"uuid": "u1", "host": "printer", "ip": "10.0.8.2,::2", "hwaddr": "AA"}]
+    leases = [{"address": "10.0.8.9", "hwaddr": "CC", "hostname": "tv"}]
+    conflicts = find_ipv4_conflicts(
+        target_ipv4="10.0.8.9",
+        moving_uuid="u1",
+        hosts=hosts,
+        leases=leases,
+    )
+    assert any(c["kind"] == "lease" and c["address"] == "10.0.8.9" for c in conflicts)
+
+
+def test_find_ipv4_conflicts_none_when_free():
+    hosts = [{"uuid": "u1", "host": "printer", "ip": "10.0.8.2,::2", "hwaddr": "AA"}]
+    assert (
+        find_ipv4_conflicts(
+            target_ipv4="10.0.8.9",
+            moving_uuid="u1",
+            hosts=hosts,
+            leases=[],
+        )
+        == []
+    )

--- a/tests/test_dhcp_host.py
+++ b/tests/test_dhcp_host.py
@@ -2,6 +2,8 @@ import pytest
 
 from opnsense_mcp.utils.dhcp_host import (
     DhcpHostRecord,
+    apply_v4_suffix,
+    apply_v6_suffix,
     format_ip_field,
     parse_ip_field,
 )
@@ -52,3 +54,27 @@ def test_record_from_search_row():
     assert rec.ipv4 == "10.0.8.2"
     assert rec.ipv6_suffix == "::2"
     assert rec.hwaddr == "c8:a3:e8:dc:1b:b9"
+
+
+def test_apply_v4_suffix_replaces_last_octet():
+    assert apply_v4_suffix("10.0.8.55", 2) == "10.0.8.2"
+
+
+def test_apply_v4_suffix_rejects_out_of_range():
+    with pytest.raises(ValueError):
+        apply_v4_suffix("10.0.8.55", 256)
+    with pytest.raises(ValueError):
+        apply_v4_suffix("10.0.8.55", 0)
+
+
+def test_apply_v4_full_address_validates():
+    assert apply_v4_suffix("10.0.8.55", "10.0.8.9") == "10.0.8.9"
+
+
+def test_apply_v6_suffix_normalizes():
+    assert apply_v6_suffix(2) == "::2"
+    assert apply_v6_suffix("::0x10") == "::10"
+
+
+def test_apply_v6_full_suffix_passthrough():
+    assert apply_v6_suffix("::abcd") == "::abcd"

--- a/tests/test_dhcp_host.py
+++ b/tests/test_dhcp_host.py
@@ -4,6 +4,7 @@ from opnsense_mcp.utils.dhcp_host import (
     DhcpHostRecord,
     apply_v4_suffix,
     apply_v6_suffix,
+    flatten_host_for_write,
     format_ip_field,
     parse_ip_field,
 )
@@ -78,3 +79,30 @@ def test_apply_v6_suffix_normalizes():
 
 def test_apply_v6_full_suffix_passthrough():
     assert apply_v6_suffix("::abcd") == "::abcd"
+
+
+def test_flatten_host_for_write_changes_ip_only():
+    row = {
+        "uuid": "u1",
+        "host": "printer",
+        "domain": "d",
+        "local": "0",
+        "ip": "10.0.8.2,::2",
+        "cnames": "",
+        "client_id": "",
+        "hwaddr": "AA:BB",
+        "lease_time": "",
+        "ignore": "0",
+        "set_tag": "t1",
+        "descr": "x",
+        "comments": "c",
+        "aliases": "",
+    }
+    rec = DhcpHostRecord.from_row(row)
+    payload = flatten_host_for_write(rec, new_ipv4="10.0.8.9", new_ipv6="::9")
+    assert payload["ip"] == "10.0.8.9,::9"
+    assert "uuid" not in payload
+    assert payload["host"] == "printer"
+    assert payload["set_tag"] == "t1"
+    assert payload["descr"] == "x"
+    assert payload["hwaddr"] == "AA:BB"

--- a/tests/test_dhcp_host.py
+++ b/tests/test_dhcp_host.py
@@ -1,0 +1,54 @@
+import pytest
+
+from opnsense_mcp.utils.dhcp_host import (
+    DhcpHostRecord,
+    format_ip_field,
+    parse_ip_field,
+)
+
+
+def test_parse_ip_field_v4_and_v6():
+    assert parse_ip_field("10.0.8.2,::2") == ("10.0.8.2", "::2")
+
+
+def test_parse_ip_field_v4_only():
+    assert parse_ip_field("10.0.8.2") == ("10.0.8.2", None)
+
+
+def test_parse_ip_field_v6_only():
+    assert parse_ip_field("::2") == (None, "::2")
+
+
+def test_parse_ip_field_empty():
+    assert parse_ip_field("") == (None, None)
+
+
+def test_format_ip_field_roundtrip():
+    assert format_ip_field("10.0.8.2", "::2") == "10.0.8.2,::2"
+    assert format_ip_field("10.0.8.2", None) == "10.0.8.2"
+    assert format_ip_field(None, "::2") == "::2"
+
+
+def test_record_from_search_row():
+    row = {
+        "uuid": "u1",
+        "host": "printer",
+        "domain": "",
+        "ip": "10.0.8.2,::2",
+        "hwaddr": "c8:a3:e8:dc:1b:b9",
+        "client_id": "",
+        "set_tag": "",
+        "descr": "VLAN81wifi",
+        "comments": "",
+        "cnames": "",
+        "aliases": "",
+        "local": "0",
+        "lease_time": "",
+        "ignore": "0",
+    }
+    rec = DhcpHostRecord.from_row(row)
+    assert rec.uuid == "u1"
+    assert rec.host == "printer"
+    assert rec.ipv4 == "10.0.8.2"
+    assert rec.ipv6_suffix == "::2"
+    assert rec.hwaddr == "c8:a3:e8:dc:1b:b9"

--- a/tests/test_dhcp_host_client.py
+++ b/tests/test_dhcp_host_client.py
@@ -1,0 +1,41 @@
+import pytest
+
+from opnsense_mcp.utils.api import OPNsenseClient
+
+
+class FakeProvider:
+    name = "dnsmasq"
+    HOST_MOVE_SUPPORTED = True
+
+    def __init__(self):
+        self.called = None
+
+    async def move_host(self, **kwargs):
+        self.called = kwargs
+        return {"status": "dry_run", "planned": {}}
+
+
+@pytest.mark.asyncio
+async def test_client_move_dhcp_host_delegates():
+    client = OPNsenseClient.__new__(OPNsenseClient)  # bypass network init
+    client._dhcp_provider = FakeProvider()
+    out = await client.move_dhcp_host(
+        identifier="printer", ipv4=2, ipv6=2, dry_run=True
+    )
+    assert out["status"] == "dry_run"
+    assert client._dhcp_provider.called["identifier"] == "printer"
+    assert client._dhcp_provider.called["ipv4_target"] == 2
+    assert client._dhcp_provider.called["ipv6_target"] == 2
+    assert client._dhcp_provider.called["dry_run"] is True
+
+
+@pytest.mark.asyncio
+async def test_client_move_dhcp_host_unsupported_backend_raises():
+    class NoSupport:
+        name = "isc"
+        HOST_MOVE_SUPPORTED = False
+
+    client = OPNsenseClient.__new__(OPNsenseClient)
+    client._dhcp_provider = NoSupport()
+    with pytest.raises(ValueError, match="host move"):
+        await client.move_dhcp_host(identifier="x", ipv4=2)

--- a/tests/test_dhcp_host_move_tool.py
+++ b/tests/test_dhcp_host_move_tool.py
@@ -1,0 +1,51 @@
+import pytest
+
+from opnsense_mcp.tools.dhcp_host_move import MoveDhcpHostTool
+
+
+class FakeClient:
+    def __init__(self):
+        self.called = None
+
+    async def move_dhcp_host(self, **kwargs):
+        self.called = kwargs
+        return {"status": "dry_run", "planned": {"host": "printer"}}
+
+
+@pytest.mark.asyncio
+async def test_tool_requires_identifier():
+    tool = MoveDhcpHostTool(FakeClient())
+    out = await tool.execute({"ipv4": 2})
+    assert out["status"] == "error"
+    assert "identifier" in out["error"].lower() or "host" in out["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_tool_requires_at_least_one_target():
+    tool = MoveDhcpHostTool(FakeClient())
+    out = await tool.execute({"host": "printer"})
+    assert out["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_tool_defaults_to_dry_run():
+    client = FakeClient()
+    tool = MoveDhcpHostTool(client)
+    out = await tool.execute({"host": "printer", "ipv4": 2})
+    assert out["status"] == "dry_run"
+    assert client.called["dry_run"] is True
+
+
+@pytest.mark.asyncio
+async def test_tool_passes_apply_flag():
+    client = FakeClient()
+    tool = MoveDhcpHostTool(client)
+    await tool.execute({"host": "printer", "ipv4": 2, "apply": True})
+    assert client.called["dry_run"] is False
+
+
+@pytest.mark.asyncio
+async def test_tool_no_client():
+    tool = MoveDhcpHostTool(None)
+    out = await tool.execute({"host": "printer", "ipv4": 2})
+    assert out["status"] == "error"

--- a/tests/test_dhcp_host_provider.py
+++ b/tests/test_dhcp_host_provider.py
@@ -105,3 +105,173 @@ async def test_get_host_uses_get_without_json_body():
     method, endpoint, kwargs = fake.calls[0]
     assert method == "GET" and endpoint.endswith("get_host/u1")
     assert "json" not in kwargs  # no body / no Content-Type on GET
+
+
+@pytest.mark.asyncio
+async def test_move_host_dry_run_does_not_write():
+    fake = FakeRequest(
+        {
+            "search_host": {
+                "rows": [
+                    {
+                        "uuid": "u1",
+                        "host": "printer",
+                        "ip": "10.0.8.55,::55",
+                        "hwaddr": "AA",
+                        "descr": "VLAN81wifi",
+                        "domain": "",
+                        "local": "0",
+                        "cnames": "",
+                        "client_id": "",
+                        "lease_time": "",
+                        "ignore": "0",
+                        "set_tag": "",
+                        "comments": "",
+                        "aliases": "",
+                    }
+                ],
+                "total": 1,
+            },
+            "leases/search": {"rows": []},
+        }
+    )
+    p = DnsmasqProvider(fake)
+    out = await p.move_host(
+        identifier="printer", ipv4_target=2, ipv6_target=2, dry_run=True
+    )
+    assert out["status"] == "dry_run"
+    assert out["planned"]["ipv4"] == {"from": "10.0.8.55", "to": "10.0.8.2"}
+    assert not any("set_host" in c[1] or "reconfigure" in c[1] for c in fake.calls)
+
+
+@pytest.mark.asyncio
+async def test_move_host_conflict_blocks():
+    fake = FakeRequest(
+        {
+            "search_host": {
+                "rows": [
+                    {
+                        "uuid": "u1",
+                        "host": "printer",
+                        "ip": "10.0.8.55,::55",
+                        "hwaddr": "AA",
+                        "descr": "",
+                        "domain": "",
+                        "local": "0",
+                        "cnames": "",
+                        "client_id": "",
+                        "lease_time": "",
+                        "ignore": "0",
+                        "set_tag": "",
+                        "comments": "",
+                        "aliases": "",
+                    },
+                    {
+                        "uuid": "u2",
+                        "host": "bose",
+                        "ip": "10.0.8.2,::2",
+                        "hwaddr": "BB",
+                    },
+                ],
+                "total": 2,
+            },
+            "leases/search": {"rows": []},
+        }
+    )
+    p = DnsmasqProvider(fake)
+    out = await p.move_host(
+        identifier="printer", ipv4_target=2, ipv6_target=None, dry_run=False
+    )
+    assert out["status"] == "error"
+    assert out["conflicts"]
+
+
+@pytest.mark.asyncio
+async def test_move_host_applies_and_reconfigures():
+    fake = FakeRequest(
+        {
+            "search_host": {
+                "rows": [
+                    {
+                        "uuid": "u1",
+                        "host": "printer",
+                        "ip": "10.0.8.55,::55",
+                        "hwaddr": "AA",
+                        "descr": "",
+                        "domain": "",
+                        "local": "0",
+                        "cnames": "",
+                        "client_id": "",
+                        "lease_time": "",
+                        "ignore": "0",
+                        "set_tag": "",
+                        "comments": "",
+                        "aliases": "",
+                    }
+                ],
+                "total": 1,
+            },
+            "leases/search": {"rows": []},
+            "set_host": {"result": "saved"},
+            "reconfigure": {"status": "ok"},
+        }
+    )
+    p = DnsmasqProvider(fake)
+    out = await p.move_host(
+        identifier="printer", ipv4_target=2, ipv6_target=2, dry_run=False
+    )
+    assert out["status"] == "success"
+    endpoints = [c[1] for c in fake.calls]
+    assert any("set_host/u1" in e for e in endpoints)
+    assert any("reconfigure" in e for e in endpoints)
+    set_call = next(c for c in fake.calls if "set_host" in c[1])
+    assert set_call[2]["json"]["host"]["ip"] == "10.0.8.2,::2"
+
+
+@pytest.mark.asyncio
+async def test_move_host_rolls_back_on_reconfigure_failure():
+    class Boom(FakeRequest):
+        async def __call__(self, method, endpoint, **kwargs):
+            self.calls.append((method, endpoint, kwargs))
+            if "reconfigure" in endpoint and not getattr(self, "_rolled", False):
+                self._rolled = True
+                raise RuntimeError("reconfigure failed")
+            for key, resp in self.responses.items():
+                if key in endpoint:
+                    return resp
+            return {}
+
+    fake = Boom(
+        {
+            "search_host": {
+                "rows": [
+                    {
+                        "uuid": "u1",
+                        "host": "printer",
+                        "ip": "10.0.8.55,::55",
+                        "hwaddr": "AA",
+                        "descr": "",
+                        "domain": "",
+                        "local": "0",
+                        "cnames": "",
+                        "client_id": "",
+                        "lease_time": "",
+                        "ignore": "0",
+                        "set_tag": "",
+                        "comments": "",
+                        "aliases": "",
+                    }
+                ],
+                "total": 1,
+            },
+            "leases/search": {"rows": []},
+            "set_host": {"result": "saved"},
+        }
+    )
+    p = DnsmasqProvider(fake)
+    out = await p.move_host(
+        identifier="printer", ipv4_target=2, ipv6_target=2, dry_run=False
+    )
+    assert out["status"] == "error"
+    set_calls = [c for c in fake.calls if "set_host" in c[1]]
+    assert set_calls[-1][2]["json"]["host"]["ip"] == "10.0.8.55,::55"

--- a/tests/test_dhcp_host_provider.py
+++ b/tests/test_dhcp_host_provider.py
@@ -1,3 +1,16 @@
+"""Tests for the DHCP host-move provider layer.
+
+Verified-live API contract (Phase 0 spike + Task 1.9, against fw.freeblizz.com):
+- ``GET get_host/{uuid}`` must carry NO JSON body — ``OPNsenseClient._make_request``
+  omits the ``Content-Type`` header when no ``json=`` kwarg is passed (requests
+  default), which the dnsmasq endpoint requires.
+- ``POST del_host/{uuid}`` must send a literal ``{}`` body; an empty body returns
+  HTTP 400 "Invalid JSON syntax".
+- ``_make_request`` raises ``RequestError`` on ``{"result": "failed"}`` responses,
+  so a rejected ``set_host`` propagates and triggers ``move_host`` rollback against
+  the real client (the FakeRequest stubs below do not model this).
+"""
+
 import pytest
 
 from opnsense_mcp.utils.dhcp_provider import (

--- a/tests/test_dhcp_host_provider.py
+++ b/tests/test_dhcp_host_provider.py
@@ -29,3 +29,79 @@ def test_require_host_provider_raises_for_unsupported():
 def test_require_host_provider_returns_supported():
     p = _Supports()
     assert require_host_provider(p) is p
+
+
+from opnsense_mcp.utils.dhcp_providers.dnsmasq import DnsmasqProvider
+
+
+class FakeRequest:
+    """Records (method, endpoint, kwargs) and returns scripted responses."""
+
+    def __init__(self, responses):
+        self.responses = responses  # dict: endpoint-substring -> response
+        self.calls = []
+
+    async def __call__(self, method, endpoint, **kwargs):
+        self.calls.append((method, endpoint, kwargs))
+        for key, resp in self.responses.items():
+            if key in endpoint:
+                return resp
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_list_hosts_returns_rows():
+    fake = FakeRequest(
+        {
+            "search_host": {
+                "rows": [
+                    {
+                        "uuid": "u1",
+                        "host": "printer",
+                        "ip": "10.0.8.2,::2",
+                        "hwaddr": "AA",
+                    }
+                ],
+                "total": 1,
+            }
+        }
+    )
+    p = DnsmasqProvider(fake)
+    rows = await p.list_hosts()
+    assert rows[0]["host"] == "printer"
+    method, endpoint, kwargs = fake.calls[0]
+    assert method == "POST" and "search_host" in endpoint
+    assert kwargs["json"]["rowCount"] == -1
+
+
+@pytest.mark.asyncio
+async def test_set_host_posts_to_uuid_with_host_envelope():
+    fake = FakeRequest({"set_host": {"result": "saved"}})
+    p = DnsmasqProvider(fake)
+    out = await p.set_host("u1", {"ip": "10.0.8.9,::9", "host": "printer"})
+    assert out["result"] == "saved"
+    method, endpoint, kwargs = fake.calls[0]
+    assert method == "POST" and endpoint.endswith("set_host/u1")
+    assert kwargs["json"] == {"host": {"ip": "10.0.8.9,::9", "host": "printer"}}
+
+
+@pytest.mark.asyncio
+async def test_del_host_sends_empty_json_body():
+    fake = FakeRequest({"del_host": {"result": "deleted"}})
+    p = DnsmasqProvider(fake)
+    out = await p.del_host("u1")
+    assert out["result"] == "deleted"
+    method, endpoint, kwargs = fake.calls[0]
+    assert method == "POST" and endpoint.endswith("del_host/u1")
+    assert kwargs["json"] == {}  # CRITICAL: empty body required
+
+
+@pytest.mark.asyncio
+async def test_get_host_uses_get_without_json_body():
+    fake = FakeRequest({"get_host": {"host": {"host": "printer"}}})
+    p = DnsmasqProvider(fake)
+    out = await p.get_host("u1")
+    assert out["host"]["host"] == "printer"
+    method, endpoint, kwargs = fake.calls[0]
+    assert method == "GET" and endpoint.endswith("get_host/u1")
+    assert "json" not in kwargs  # no body / no Content-Type on GET

--- a/tests/test_dhcp_host_provider.py
+++ b/tests/test_dhcp_host_provider.py
@@ -17,6 +17,9 @@ from opnsense_mcp.utils.dhcp_provider import (
     provider_supports_host_move,
     require_host_provider,
 )
+from opnsense_mcp.utils.dhcp_providers.dnsmasq import DnsmasqProvider
+from opnsense_mcp.utils.dhcp_providers.isc import ISCProvider
+from opnsense_mcp.utils.dhcp_providers.kea import KeaProvider
 
 
 class _Supports:
@@ -42,9 +45,6 @@ def test_require_host_provider_raises_for_unsupported():
 def test_require_host_provider_returns_supported():
     p = _Supports()
     assert require_host_provider(p) is p
-
-
-from opnsense_mcp.utils.dhcp_providers.dnsmasq import DnsmasqProvider
 
 
 class FakeRequest:
@@ -385,3 +385,15 @@ async def test_find_host_falls_back_to_full_list_on_fuzzy_miss():
     p = DnsmasqProvider(fake)
     row = await p._find_host("printer")
     assert row is not None and row["uuid"] == "u1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cls", [ISCProvider, KeaProvider])
+async def test_move_host_unsupported_backends(cls):
+    p = cls(FakeRequest({}))
+    assert getattr(cls, "HOST_MOVE_SUPPORTED", False) is False
+    out = await p.move_host(
+        identifier="x", ipv4_target=2, ipv6_target=None, dry_run=True
+    )
+    assert out["status"] == "error"
+    assert "not supported" in out["error"].lower()

--- a/tests/test_dhcp_host_provider.py
+++ b/tests/test_dhcp_host_provider.py
@@ -226,6 +226,9 @@ async def test_move_host_applies_and_reconfigures():
     assert any("reconfigure" in e for e in endpoints)
     set_call = next(c for c in fake.calls if "set_host" in c[1])
     assert set_call[2]["json"]["host"]["ip"] == "10.0.8.2,::2"
+    assert (
+        len([c for c in fake.calls if "set_host" in c[1]]) == 1
+    )  # no spurious rollback
 
 
 @pytest.mark.asyncio
@@ -275,3 +278,97 @@ async def test_move_host_rolls_back_on_reconfigure_failure():
     assert out["status"] == "error"
     set_calls = [c for c in fake.calls if "set_host" in c[1]]
     assert set_calls[-1][2]["json"]["host"]["ip"] == "10.0.8.55,::55"
+
+
+@pytest.mark.asyncio
+async def test_move_host_noop_when_no_change():
+    # ip field uses "::37" because apply_v6_suffix(55) -> "::37" (55 decimal = 0x37)
+    fake = FakeRequest(
+        {
+            "search_host": {
+                "rows": [
+                    {
+                        "uuid": "u1",
+                        "host": "printer",
+                        "ip": "10.0.8.55,::37",
+                        "hwaddr": "AA",
+                        "descr": "",
+                        "domain": "",
+                        "local": "0",
+                        "cnames": "",
+                        "client_id": "",
+                        "lease_time": "",
+                        "ignore": "0",
+                        "set_tag": "",
+                        "comments": "",
+                        "aliases": "",
+                    }
+                ],
+                "total": 1,
+            },
+        }
+    )
+    p = DnsmasqProvider(fake)
+    # ipv4_target=55 -> "10.0.8.55" (same); ipv6_target=55 -> "::37" (same) -> no change
+    out = await p.move_host(
+        identifier="printer", ipv4_target=55, ipv6_target=55, dry_run=False
+    )
+    assert out["status"] == "noop"
+    assert not any("set_host" in c[1] or "reconfigure" in c[1] for c in fake.calls)
+
+
+@pytest.mark.asyncio
+async def test_move_host_not_found_returns_error():
+    fake = FakeRequest({"search_host": {"rows": [], "total": 0}})
+    p = DnsmasqProvider(fake)
+    out = await p.move_host(
+        identifier="ghost", ipv4_target=2, ipv6_target=None, dry_run=True
+    )
+    assert out["status"] == "error"
+    assert "ghost" in out["error"]
+
+
+@pytest.mark.asyncio
+async def test_find_host_falls_back_to_full_list_on_fuzzy_miss():
+    # First call (with search=) returns a non-matching row (matched on descr);
+    # second call (full list) returns the real host. The endpoint substring is
+    # identical for both, so use a stateful fake that returns different payloads
+    # per call count.
+    class SeqRequest:
+        def __init__(self):
+            self.calls = []
+            self._n = 0
+
+        async def __call__(self, method, endpoint, **kwargs):
+            self.calls.append((method, endpoint, kwargs))
+            if "search_host" in endpoint:
+                self._n += 1
+                if self._n == 1:
+                    return {
+                        "rows": [
+                            {
+                                "uuid": "x",
+                                "host": "other",
+                                "ip": "10.0.8.9,::9",
+                                "hwaddr": "ZZ",
+                                "descr": "printer rack",
+                            }
+                        ]
+                    }
+                return {
+                    "rows": [
+                        {
+                            "uuid": "u1",
+                            "host": "printer",
+                            "ip": "10.0.8.55,::55",
+                            "hwaddr": "AA",
+                            "descr": "",
+                        }
+                    ]
+                }
+            return {}
+
+    fake = SeqRequest()
+    p = DnsmasqProvider(fake)
+    row = await p._find_host("printer")
+    assert row is not None and row["uuid"] == "u1"

--- a/tests/test_dhcp_host_provider.py
+++ b/tests/test_dhcp_host_provider.py
@@ -1,0 +1,31 @@
+import pytest
+
+from opnsense_mcp.utils.dhcp_provider import (
+    provider_supports_host_move,
+    require_host_provider,
+)
+
+
+class _Supports:
+    name = "dnsmasq"
+    HOST_MOVE_SUPPORTED = True
+
+
+class _NoSupport:
+    name = "isc"
+    HOST_MOVE_SUPPORTED = False
+
+
+def test_provider_supports_host_move():
+    assert provider_supports_host_move(_Supports()) is True
+    assert provider_supports_host_move(_NoSupport()) is False
+
+
+def test_require_host_provider_raises_for_unsupported():
+    with pytest.raises(ValueError, match="host move"):
+        require_host_provider(_NoSupport())
+
+
+def test_require_host_provider_returns_supported():
+    p = _Supports()
+    assert require_host_provider(p) is p


### PR DESCRIPTION
## Summary

- Add DHCP host reservation model, dnsmasq host CRUD, and `move_host` orchestration with rollback and IPv4 conflict detection
- Expose `move_dhcp_host` MCP tool (hostname/MAC identifier, optional v4/v6 targets, dry-run via `apply=false`)
- Document live feasibility findings (DUID/client_id requirements, dnsmasq vs ISC/Kea gaps)

## Test plan

- [x] `uv run pytest tests/` — 133 passed locally
- [x] `uv run ruff check .` and `uv run ruff format --check .`
- [x] Live validation on dnsmasq firewall: MacBook move to `10.0.8.6,::6`, trogdor wired `10.0.2.80,::80` after setting machine DUID in `client_id`
- [ ] Deploy MCP on strongpod and exercise `move_dhcp_host` against production reservations


Made with [Cursor](https://cursor.com)