### PR TITLE
feat(dhcp): add list_dhcp_hosts MCP tool

### DIFF
--- a/opnsense_mcp/server.py
+++ b/opnsense_mcp/server.py
@@ -85,6 +85,7 @@ from opnsense_mcp.tools.aliases import AliasesTool
 from opnsense_mcp.tools.arp import ARPTool
 from opnsense_mcp.tools.dhcp import DHCPTool
 from opnsense_mcp.tools.dhcp_host_move import MoveDhcpHostTool
+from opnsense_mcp.tools.dhcp_hosts import ListDhcpHostsTool
 from opnsense_mcp.tools.dhcp_lease_delete import DHCPLeaseDeleteTool
 from opnsense_mcp.tools.dhcp_subnet_dns import (
     ListDhcpSubnetDnsTool,
@@ -199,6 +200,7 @@ async def handle_message(
     list_dhcp_subnet_dns_tool: ListDhcpSubnetDnsTool,
     set_dhcp_subnet_dns_tool: SetDhcpSubnetDnsTool,
     move_dhcp_host_tool: MoveDhcpHostTool,
+    list_dhcp_hosts_tool: ListDhcpHostsTool,
     lldp_tool: LLDPTool,
     system_tool: SystemTool,
     fw_rules_tool: FwRulesTool,
@@ -359,6 +361,11 @@ async def handle_message(
                 "name": MoveDhcpHostTool.name,
                 "description": MoveDhcpHostTool.description,
                 "inputSchema": MoveDhcpHostTool.input_schema,
+            },
+            {
+                "name": ListDhcpHostsTool.name,
+                "description": ListDhcpHostsTool.description,
+                "inputSchema": ListDhcpHostsTool.input_schema,
             },
             {
                 "name": "lldp",
@@ -878,6 +885,13 @@ async def handle_message(
                 "id": msg_id,
                 "result": {"content": [{"type": "text", "text": str(result)}]},
             }
+        if tool_name == "list_dhcp_hosts":
+            result = await list_dhcp_hosts_tool.execute(arguments)
+            return {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {"content": [{"type": "text", "text": str(result)}]},
+            }
         if tool_name == "get_logs":
             logs = await firewall_logs.get_logs(
                 limit=arguments.get("limit", 500),
@@ -1087,6 +1101,7 @@ def main() -> None:
     list_dhcp_subnet_dns_tool = ListDhcpSubnetDnsTool(client)
     set_dhcp_subnet_dns_tool = SetDhcpSubnetDnsTool(client)
     move_dhcp_host_tool = MoveDhcpHostTool(client)
+    list_dhcp_hosts_tool = ListDhcpHostsTool(client)
     lldp_tool = LLDPTool(client)
     system_tool = SystemTool(client)
     fw_rules_tool = FwRulesTool(client)
@@ -1154,6 +1169,7 @@ def main() -> None:
                     list_dhcp_subnet_dns_tool,
                     set_dhcp_subnet_dns_tool,
                     move_dhcp_host_tool,
+                    list_dhcp_hosts_tool,
                     lldp_tool,
                     system_tool,
                     fw_rules_tool,

--- a/opnsense_mcp/tools/dhcp_hosts.py
+++ b/opnsense_mcp/tools/dhcp_hosts.py
@@ -1,0 +1,99 @@
+"""MCP tool to list DHCP host reservations (dnsmasq search_host rows)."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from opnsense_mcp.utils.dhcp_host import DhcpHostRecord
+
+if TYPE_CHECKING:
+    from opnsense_mcp.utils.api import OPNsenseClient
+
+logger = logging.getLogger(__name__)
+
+
+def _matches_descr(record: DhcpHostRecord, descr: str) -> bool:
+    """Return True when the reservation descr contains ``descr`` (case-insensitive)."""
+    needle = descr.strip().lower()
+    if not needle:
+        return True
+    haystack = str(record.raw.get("descr") or "").lower()
+    return needle in haystack
+
+
+class ListDhcpHostsTool:
+    """List dnsmasq DHCP host reservations (static mappings), not active leases."""
+
+    name = "list_dhcp_hosts"
+    description = (
+        "List DHCP host reservations from the dnsmasq host table (Services → DHCPv4 → "
+        "Hosts). Unlike the dhcp tool (leases), this returns configured static mappings "
+        "including IPv4, optional ::N IPv6 suffix, MAC, client_id, and descr."
+    )
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "search": {
+                "type": "string",
+                "description": (
+                    "Optional filter passed to OPNsense searchPhrase "
+                    "(hostname, MAC, IP fragment, etc.)"
+                ),
+                "optional": True,
+            },
+            "descr": {
+                "type": "string",
+                "description": (
+                    "Optional client-side filter: reservation descr substring "
+                    "(e.g. VLAN2wired)"
+                ),
+                "optional": True,
+            },
+            "missing_ipv6": {
+                "type": "boolean",
+                "description": (
+                    "When true, return only reservations with IPv4 but no ::N IPv6 suffix"
+                ),
+                "optional": True,
+            },
+        },
+        "required": [],
+    }
+
+    def __init__(self, client: OPNsenseClient | None) -> None:
+        """Initialize the tool."""
+        self.client = client
+
+    async def execute(self, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Fetch and optionally filter host reservation rows."""
+        params = params or {}
+        if not self.client:
+            return {"status": "error", "error": "No client available"}
+
+        search = str(params.get("search") or "").strip()
+        descr = str(params.get("descr") or "").strip()
+        missing_ipv6 = bool(params.get("missing_ipv6", False))
+
+        try:
+            rows = await self.client.list_dhcp_hosts(search=search)
+        except Exception as exc:
+            logger.exception("Failed to list DHCP host reservations")
+            return {"status": "error", "error": str(exc)}
+
+        records = [DhcpHostRecord.from_row(row) for row in rows]
+        if descr:
+            records = [rec for rec in records if _matches_descr(rec, descr)]
+        if missing_ipv6:
+            records = [rec for rec in records if rec.ipv4 and not rec.ipv6_suffix]
+
+        hosts = [rec.to_summary() for rec in records]
+        missing_ipv6_count = sum(
+            1 for host in hosts if host.get("ipv4") and not host.get("has_ipv6")
+        )
+        return {
+            "status": "success",
+            "count": len(hosts),
+            "missing_ipv6_count": missing_ipv6_count,
+            "hosts": hosts,
+        }

--- a/opnsense_mcp/utils/api.py
+++ b/opnsense_mcp/utils/api.py
@@ -929,6 +929,14 @@ class OPNsenseClient:
             dry_run=dry_run,
         )
 
+    async def list_dhcp_hosts(self, *, search: str = "") -> list[dict[str, Any]]:
+        """Return dnsmasq host reservation rows (optional API searchPhrase)."""
+        await self._ensure_dhcp_provider()
+        if self._dhcp_provider is None:
+            raise RuntimeError("DHCP provider not initialized")
+        provider = require_host_provider(self._dhcp_provider)
+        return await provider.list_hosts(search=search)
+
     async def get_firewall_logs(
         self: "OPNsenseClient", limit: int = 100
     ) -> list[dict[str, Any]]:

--- a/opnsense_mcp/utils/dhcp_host.py
+++ b/opnsense_mcp/utils/dhcp_host.py
@@ -72,6 +72,20 @@ class DhcpHostRecord:
             raw=dict(row),
         )
 
+    def to_summary(self) -> dict[str, Any]:
+        """Return a normalized reservation row for MCP list output."""
+        return {
+            "uuid": self.uuid,
+            "host": self.host,
+            "descr": str(self.raw.get("descr") or ""),
+            "hwaddr": self.hwaddr,
+            "client_id": str(self.raw.get("client_id") or ""),
+            "ipv4": self.ipv4,
+            "ipv6_suffix": self.ipv6_suffix,
+            "has_ipv6": bool(self.ipv6_suffix),
+            "ip": str(self.raw.get("ip") or ""),
+        }
+
 
 def apply_v4_suffix(current_ipv4: str, target: int | str) -> str:
     """Return a new IPv4 address: replace the last octet (int target) or

--- a/tests/test_dhcp_host.py
+++ b/tests/test_dhcp_host.py
@@ -58,6 +58,23 @@ def test_record_from_search_row():
     assert rec.hwaddr == "c8:a3:e8:dc:1b:b9"
 
 
+def test_record_to_summary():
+    row = {
+        "uuid": "u1",
+        "host": "printer",
+        "ip": "10.0.8.2,::2",
+        "hwaddr": "c8:a3:e8:dc:1b:b9",
+        "client_id": "duid-here",
+        "descr": "VLAN81wifi",
+    }
+    summary = DhcpHostRecord.from_row(row).to_summary()
+    assert summary["ipv4"] == "10.0.8.2"
+    assert summary["ipv6_suffix"] == "::2"
+    assert summary["has_ipv6"] is True
+    assert summary["descr"] == "VLAN81wifi"
+    assert summary["client_id"] == "duid-here"
+
+
 def test_apply_v4_suffix_replaces_last_octet():
     assert apply_v4_suffix("10.0.8.55", 2) == "10.0.8.2"
 

--- a/tests/test_dhcp_hosts_client.py
+++ b/tests/test_dhcp_hosts_client.py
@@ -1,0 +1,36 @@
+import pytest
+
+from opnsense_mcp.utils.api import OPNsenseClient
+
+
+class FakeProvider:
+    name = "dnsmasq"
+    HOST_MOVE_SUPPORTED = True
+
+    def __init__(self):
+        self.called = None
+
+    async def list_hosts(self, search=""):
+        self.called = search
+        return [{"uuid": "u1", "host": "printer", "ip": "10.0.8.2,::2"}]
+
+
+@pytest.mark.asyncio
+async def test_client_list_dhcp_hosts_delegates():
+    client = OPNsenseClient.__new__(OPNsenseClient)
+    client._dhcp_provider = FakeProvider()
+    rows = await client.list_dhcp_hosts(search="printer")
+    assert len(rows) == 1
+    assert client._dhcp_provider.called == "printer"
+
+
+@pytest.mark.asyncio
+async def test_client_list_dhcp_hosts_unsupported_backend_raises():
+    class NoSupport:
+        name = "isc"
+        HOST_MOVE_SUPPORTED = False
+
+    client = OPNsenseClient.__new__(OPNsenseClient)
+    client._dhcp_provider = NoSupport()
+    with pytest.raises(ValueError, match="host move"):
+        await client.list_dhcp_hosts()

--- a/tests/test_dhcp_hosts_tool.py
+++ b/tests/test_dhcp_hosts_tool.py
@@ -1,0 +1,104 @@
+import pytest
+
+from opnsense_mcp.tools.dhcp_hosts import ListDhcpHostsTool
+
+
+class FakeClient:
+    def __init__(self, rows):
+        self.rows = rows
+        self.called = None
+
+    async def list_dhcp_hosts(self, *, search=""):
+        self.called = search
+        return self.rows
+
+
+@pytest.mark.asyncio
+async def test_tool_lists_all_hosts():
+    rows = [
+        {
+            "uuid": "u1",
+            "host": "printer",
+            "ip": "10.0.8.2,::2",
+            "hwaddr": "aa:bb:cc:dd:ee:ff",
+            "descr": "VLAN81wifi",
+        },
+        {
+            "uuid": "u2",
+            "host": "ztx",
+            "ip": "10.0.5.6",
+            "hwaddr": "11:22:33:44:55:66",
+            "descr": "VLAN5LAB",
+        },
+    ]
+    client = FakeClient(rows)
+    tool = ListDhcpHostsTool(client)
+    out = await tool.execute({})
+    assert out["status"] == "success"
+    assert out["count"] == 2
+    assert out["missing_ipv6_count"] == 1
+    assert client.called == ""
+
+
+@pytest.mark.asyncio
+async def test_tool_passes_search_to_client():
+    client = FakeClient([])
+    tool = ListDhcpHostsTool(client)
+    await tool.execute({"search": "printer"})
+    assert client.called == "printer"
+
+
+@pytest.mark.asyncio
+async def test_tool_filters_by_descr():
+    rows = [
+        {
+            "uuid": "u1",
+            "host": "a",
+            "ip": "10.0.2.1,::1",
+            "hwaddr": "aa:bb:cc:dd:ee:01",
+            "descr": "VLAN2wired",
+        },
+        {
+            "uuid": "u2",
+            "host": "b",
+            "ip": "10.0.8.2,::2",
+            "hwaddr": "aa:bb:cc:dd:ee:02",
+            "descr": "VLAN81wifi",
+        },
+    ]
+    tool = ListDhcpHostsTool(FakeClient(rows))
+    out = await tool.execute({"descr": "vlan2"})
+    assert out["count"] == 1
+    assert out["hosts"][0]["host"] == "a"
+
+
+@pytest.mark.asyncio
+async def test_tool_missing_ipv6_filter():
+    rows = [
+        {
+            "uuid": "u1",
+            "host": "a",
+            "ip": "10.0.2.1,::1",
+            "hwaddr": "aa:bb:cc:dd:ee:01",
+            "descr": "VLAN2wired",
+        },
+        {
+            "uuid": "u2",
+            "host": "b",
+            "ip": "10.0.5.6",
+            "hwaddr": "aa:bb:cc:dd:ee:02",
+            "descr": "VLAN5LAB",
+        },
+    ]
+    tool = ListDhcpHostsTool(FakeClient(rows))
+    out = await tool.execute({"missing_ipv6": True})
+    assert out["count"] == 1
+    assert out["hosts"][0]["host"] == "b"
+    assert out["missing_ipv6_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_tool_no_client():
+    tool = ListDhcpHostsTool(None)
+    out = await tool.execute({})
+    assert out["status"] == "error"


### PR DESCRIPTION
## Summary

- Add `list_dhcp_hosts` MCP tool to read dnsmasq static host reservations (not active leases)
- Support optional `search`, `descr`, and `missing_ipv6` filters for reservation audits
- Normalize rows with IPv4, `::N` suffix, MAC, client_id, and summary counts

## Test plan

- [x] `uv run pytest tests/` — 142 passed locally
- [x] `uv run ruff check .` and `uv run ruff format --check .`
- [ ] Deploy MCP on strongpod and exercise `list_dhcp_hosts(descr="VLAN2wired")` and `missing_ipv6=true`


Made with [Cursor](https://cursor.com)