### PR TITLE
feat(dhcp): add rm_dhcp_host MCP tool

### DIFF
--- a/opnsense_mcp/server.py
+++ b/opnsense_mcp/server.py
@@ -101,6 +101,7 @@ from opnsense_mcp.tools.lldp import LLDPTool
 from opnsense_mcp.tools.mkdns import MkdnsTool
 from opnsense_mcp.tools.mkfw_rule import MkfwRuleTool
 from opnsense_mcp.tools.packet_capture import PacketCaptureTool2 as PacketCaptureTool
+from opnsense_mcp.tools.rm_dhcp_host import RmDhcpHostTool
 from opnsense_mcp.tools.rmdns import RmdnsTool
 from opnsense_mcp.tools.rmfw_rule import RmfwRuleTool
 from opnsense_mcp.tools.set_fw_rule import SetFwRuleTool
@@ -201,6 +202,7 @@ async def handle_message(
     set_dhcp_subnet_dns_tool: SetDhcpSubnetDnsTool,
     move_dhcp_host_tool: MoveDhcpHostTool,
     list_dhcp_hosts_tool: ListDhcpHostsTool,
+    rm_dhcp_host_tool: RmDhcpHostTool,
     lldp_tool: LLDPTool,
     system_tool: SystemTool,
     fw_rules_tool: FwRulesTool,
@@ -366,6 +368,11 @@ async def handle_message(
                 "name": ListDhcpHostsTool.name,
                 "description": ListDhcpHostsTool.description,
                 "inputSchema": ListDhcpHostsTool.input_schema,
+            },
+            {
+                "name": RmDhcpHostTool.name,
+                "description": RmDhcpHostTool.description,
+                "inputSchema": RmDhcpHostTool.input_schema,
             },
             {
                 "name": "lldp",
@@ -892,6 +899,13 @@ async def handle_message(
                 "id": msg_id,
                 "result": {"content": [{"type": "text", "text": str(result)}]},
             }
+        if tool_name == "rm_dhcp_host":
+            result = await rm_dhcp_host_tool.execute(arguments)
+            return {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {"content": [{"type": "text", "text": str(result)}]},
+            }
         if tool_name == "get_logs":
             logs = await firewall_logs.get_logs(
                 limit=arguments.get("limit", 500),
@@ -1102,6 +1116,7 @@ def main() -> None:
     set_dhcp_subnet_dns_tool = SetDhcpSubnetDnsTool(client)
     move_dhcp_host_tool = MoveDhcpHostTool(client)
     list_dhcp_hosts_tool = ListDhcpHostsTool(client)
+    rm_dhcp_host_tool = RmDhcpHostTool(client)
     lldp_tool = LLDPTool(client)
     system_tool = SystemTool(client)
     fw_rules_tool = FwRulesTool(client)
@@ -1170,6 +1185,7 @@ def main() -> None:
                     set_dhcp_subnet_dns_tool,
                     move_dhcp_host_tool,
                     list_dhcp_hosts_tool,
+                    rm_dhcp_host_tool,
                     lldp_tool,
                     system_tool,
                     fw_rules_tool,

--- a/opnsense_mcp/tools/rm_dhcp_host.py
+++ b/opnsense_mcp/tools/rm_dhcp_host.py
@@ -1,0 +1,60 @@
+"""MCP tool to delete a DHCP host reservation."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from opnsense_mcp.utils.api import OPNsenseClient
+
+logger = logging.getLogger(__name__)
+
+
+class RmDhcpHostTool:
+    """Delete a dnsmasq DHCP host reservation."""
+
+    name = "rm_dhcp_host"
+    description = (
+        "Delete a DHCP host reservation from the dnsmasq host table "
+        "(Services → DHCPv4 → Hosts). Accepts hostname, MAC, or reservation uuid. "
+        "Defaults to a dry run; pass apply=true to delete and reconfigure dnsmasq."
+    )
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "host": {
+                "type": "string",
+                "description": "Hostname, MAC, or reservation uuid to delete",
+            },
+            "apply": {
+                "type": "boolean",
+                "description": "Apply the deletion. Omit/false = dry run.",
+            },
+        },
+        "required": ["host"],
+    }
+
+    def __init__(self, client: OPNsenseClient | None) -> None:
+        """Initialize the tool."""
+        self.client = client
+
+    async def execute(self, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Validate args and delegate deletion to the client."""
+        params = params or {}
+        if not self.client:
+            return {"status": "error", "error": "No client available"}
+
+        identifier = str(params.get("host") or "").strip()
+        if not identifier:
+            return {"status": "error", "error": "host (hostname, MAC, or uuid) is required"}
+
+        apply = bool(params.get("apply", False))
+        try:
+            return await self.client.delete_dhcp_host(
+                identifier=identifier,
+                dry_run=not apply,
+            )
+        except Exception as exc:
+            logger.exception("Failed to delete DHCP host")
+            return {"status": "error", "error": str(exc)}

--- a/opnsense_mcp/utils/api.py
+++ b/opnsense_mcp/utils/api.py
@@ -937,6 +937,19 @@ class OPNsenseClient:
         provider = require_host_provider(self._dhcp_provider)
         return await provider.list_hosts(search=search)
 
+    async def delete_dhcp_host(
+        self,
+        *,
+        identifier: str,
+        dry_run: bool = True,
+    ) -> dict[str, Any]:
+        """Delete a dnsmasq host reservation by hostname, MAC, or uuid."""
+        await self._ensure_dhcp_provider()
+        if self._dhcp_provider is None:
+            raise RuntimeError("DHCP provider not initialized")
+        provider = require_host_provider(self._dhcp_provider)
+        return await provider.delete_host(identifier=identifier, dry_run=dry_run)
+
     async def get_firewall_logs(
         self: "OPNsenseClient", limit: int = 100
     ) -> list[dict[str, Any]]:

--- a/opnsense_mcp/utils/dhcp_providers/dnsmasq.py
+++ b/opnsense_mcp/utils/dhcp_providers/dnsmasq.py
@@ -619,3 +619,56 @@ class DnsmasqProvider:
                 "renews or reboots. IPv6 applies only to stateful-DHCPv6 clients."
             ),
         }
+
+    async def _resolve_host_row(self, identifier: str) -> dict[str, Any] | None:
+        """Find a host row by hostname, MAC, or reservation uuid."""
+        row = await self._find_host(identifier)
+        if row is not None:
+            return row
+        needle = identifier.strip().lower()
+        for candidate in await self.list_hosts():
+            if str(candidate.get("uuid") or "").lower() == needle:
+                return candidate
+        return None
+
+    async def delete_host(
+        self,
+        *,
+        identifier: str,
+        dry_run: bool = True,
+    ) -> dict[str, Any]:
+        """Delete a host reservation by hostname, MAC, or uuid."""
+        row = await self._resolve_host_row(identifier)
+        if row is None:
+            return {
+                "status": "error",
+                "error": f"No host reservation matched {identifier!r}",
+            }
+        rec = DhcpHostRecord.from_row(row)
+        planned = rec.to_summary()
+
+        if dry_run:
+            return {
+                "status": "dry_run",
+                "backend": self.name,
+                "planned": planned,
+                "note": "No changes applied. Re-run with dry_run=false to apply.",
+            }
+
+        try:
+            await self.del_host(rec.uuid)
+            await self._reconfigure()
+        except Exception as exc:
+            logger.exception("host delete failed for %s", rec.host)
+            return {
+                "status": "error",
+                "backend": self.name,
+                "planned": planned,
+                "error": str(exc),
+            }
+
+        return {
+            "status": "success",
+            "backend": self.name,
+            "deleted": planned,
+        }

--- a/opnsense_mcp/utils/dhcp_providers/isc.py
+++ b/opnsense_mcp/utils/dhcp_providers/isc.py
@@ -113,3 +113,15 @@ class ISCProvider:
             "status": "error",
             "error": f"Host move not supported by {self.name} backend",
         }
+
+    async def delete_host(
+        self,
+        *,
+        identifier: str,
+        dry_run: bool = True,
+    ) -> dict[str, Any]:
+        """Host delete is not supported on this backend yet."""
+        return {
+            "status": "error",
+            "error": f"Host delete not supported by {self.name} backend",
+        }

--- a/opnsense_mcp/utils/dhcp_providers/kea.py
+++ b/opnsense_mcp/utils/dhcp_providers/kea.py
@@ -350,3 +350,15 @@ class KeaProvider:
             "status": "error",
             "error": f"Host move not supported by {self.name} backend",
         }
+
+    async def delete_host(
+        self,
+        *,
+        identifier: str,
+        dry_run: bool = True,
+    ) -> dict[str, Any]:
+        """Host delete is not supported on this backend yet."""
+        return {
+            "status": "error",
+            "error": f"Host delete not supported by {self.name} backend",
+        }

--- a/tests/test_dhcp_host_provider.py
+++ b/tests/test_dhcp_host_provider.py
@@ -397,3 +397,91 @@ async def test_move_host_unsupported_backends(cls):
     )
     assert out["status"] == "error"
     assert "not supported" in out["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_delete_host_dry_run_does_not_write():
+    fake = FakeRequest(
+        {
+            "search_host": {
+                "rows": [
+                    {
+                        "uuid": "u1",
+                        "host": "chines",
+                        "ip": "10.0.2.4,::4",
+                        "hwaddr": "98:fd:b4:9a:05:53",
+                        "descr": "VLAN2wired",
+                    }
+                ],
+                "total": 1,
+            },
+        }
+    )
+    p = DnsmasqProvider(fake)
+    out = await p.delete_host(identifier="chines", dry_run=True)
+    assert out["status"] == "dry_run"
+    assert out["planned"]["host"] == "chines"
+    assert not any("del_host" in c[1] or "reconfigure" in c[1] for c in fake.calls)
+
+
+@pytest.mark.asyncio
+async def test_delete_host_applies_and_reconfigures():
+    fake = FakeRequest(
+        {
+            "search_host": {
+                "rows": [
+                    {
+                        "uuid": "u1",
+                        "host": "chines",
+                        "ip": "10.0.2.4,::4",
+                        "hwaddr": "98:fd:b4:9a:05:53",
+                        "descr": "VLAN2wired",
+                    }
+                ],
+                "total": 1,
+            },
+            "del_host": {"result": "deleted"},
+            "reconfigure": {"status": "ok"},
+        }
+    )
+    p = DnsmasqProvider(fake)
+    out = await p.delete_host(identifier="chines", dry_run=False)
+    assert out["status"] == "success"
+    assert out["deleted"]["host"] == "chines"
+    endpoints = [c[1] for c in fake.calls]
+    assert any("del_host/u1" in e for e in endpoints)
+    assert any("reconfigure" in e for e in endpoints)
+
+
+@pytest.mark.asyncio
+async def test_delete_host_finds_by_uuid():
+    fake = FakeRequest(
+        {
+            "search_host": {
+                "rows": [
+                    {
+                        "uuid": "u1",
+                        "host": "chines",
+                        "ip": "10.0.2.4,::4",
+                        "hwaddr": "98:fd:b4:9a:05:53",
+                    }
+                ],
+                "total": 1,
+            },
+            "del_host": {"result": "deleted"},
+            "reconfigure": {"status": "ok"},
+        }
+    )
+    p = DnsmasqProvider(fake)
+    out = await p.delete_host(identifier="u1", dry_run=False)
+    assert out["status"] == "success"
+    assert any("del_host/u1" in c[1] for c in fake.calls)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cls", [ISCProvider, KeaProvider])
+async def test_delete_host_unsupported_backends(cls):
+    p = cls(FakeRequest({}))
+    out = await p.delete_host(identifier="x", dry_run=True)
+    assert out["status"] == "error"
+    assert "not supported" in out["error"].lower()

--- a/tests/test_rm_dhcp_host_client.py
+++ b/tests/test_rm_dhcp_host_client.py
@@ -1,0 +1,37 @@
+import pytest
+
+from opnsense_mcp.utils.api import OPNsenseClient
+
+
+class FakeProvider:
+    name = "dnsmasq"
+    HOST_MOVE_SUPPORTED = True
+
+    def __init__(self):
+        self.called = None
+
+    async def delete_host(self, **kwargs):
+        self.called = kwargs
+        return {"status": "dry_run", "planned": {}}
+
+
+@pytest.mark.asyncio
+async def test_client_delete_dhcp_host_delegates():
+    client = OPNsenseClient.__new__(OPNsenseClient)
+    client._dhcp_provider = FakeProvider()
+    out = await client.delete_dhcp_host(identifier="chines", dry_run=True)
+    assert out["status"] == "dry_run"
+    assert client._dhcp_provider.called["identifier"] == "chines"
+    assert client._dhcp_provider.called["dry_run"] is True
+
+
+@pytest.mark.asyncio
+async def test_client_delete_dhcp_host_unsupported_backend_raises():
+    class NoSupport:
+        name = "isc"
+        HOST_MOVE_SUPPORTED = False
+
+    client = OPNsenseClient.__new__(OPNsenseClient)
+    client._dhcp_provider = NoSupport()
+    with pytest.raises(ValueError, match="host move"):
+        await client.delete_dhcp_host(identifier="chines")

--- a/tests/test_rm_dhcp_host_tool.py
+++ b/tests/test_rm_dhcp_host_tool.py
@@ -1,0 +1,44 @@
+import pytest
+
+from opnsense_mcp.tools.rm_dhcp_host import RmDhcpHostTool
+
+
+class FakeClient:
+    def __init__(self):
+        self.called = None
+
+    async def delete_dhcp_host(self, **kwargs):
+        self.called = kwargs
+        return {"status": "dry_run", "planned": {"host": "chines"}}
+
+
+@pytest.mark.asyncio
+async def test_tool_requires_host():
+    tool = RmDhcpHostTool(FakeClient())
+    out = await tool.execute({})
+    assert out["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_tool_defaults_to_dry_run():
+    client = FakeClient()
+    tool = RmDhcpHostTool(client)
+    out = await tool.execute({"host": "chines"})
+    assert out["status"] == "dry_run"
+    assert client.called["identifier"] == "chines"
+    assert client.called["dry_run"] is True
+
+
+@pytest.mark.asyncio
+async def test_tool_passes_apply_flag():
+    client = FakeClient()
+    tool = RmDhcpHostTool(client)
+    await tool.execute({"host": "chines", "apply": True})
+    assert client.called["dry_run"] is False
+
+
+@pytest.mark.asyncio
+async def test_tool_no_client():
+    tool = RmDhcpHostTool(None)
+    out = await tool.execute({"host": "chines"})
+    assert out["status"] == "error"


### PR DESCRIPTION
## Summary

- Add `rm_dhcp_host` MCP tool to delete dnsmasq static host reservations
- Accept hostname, MAC, or reservation uuid; defaults to dry run (`apply=false`)
- Wire through existing `del_host` API + dnsmasq reconfigure

## Test plan

- [x] `uv run pytest tests/` — 153 passed locally
- [x] `uv run ruff check .`
- [ ] Deploy to strongpod and delete stale `chines` reservation via MCP


Made with [Cursor](https://cursor.com)