### PR TITLE
feat: add Streamable HTTP transport (MCP spec 2025-03-26)

### DIFF
--- a/deploy/Containerfile
+++ b/deploy/Containerfile
@@ -1,6 +1,7 @@
 # Build from repository root:
 #   podman build -f deploy/Containerfile -t localhost/opnsense-mcp:test .
-# The SSE listener is HTTP only. Terminate TLS on the host (see deploy/TLS.md + Caddy examples).
+# The MCP listener is HTTP only. Terminate TLS on the host (see deploy/TLS.md + Caddy examples).
+# Clients connect to /mcp path (Streamable HTTP, MCP spec 2025-03-26).
 
 FROM docker.io/library/python:3.12-slim-bookworm
 
@@ -34,11 +35,10 @@ RUN printf '%s\n' \
 
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt && \
-    pip install --no-cache-dir -e . && \
-    pip install --no-cache-dir "mcp-proxy>=0.11.0"
+    pip install --no-cache-dir -e .
 
 EXPOSE 8765
 
-# mcp-proxy: SSE to stdio — spawns `python3 main.py` with pipes.
-# Remote MCP URL path is typically /sse (see mcp-proxy README).
-CMD ["mcp-proxy", "--host=0.0.0.0", "--port=8765", "--pass-environment", "--", "python3", "main.py"]
+# FastMCP native Streamable HTTP — no mcp-proxy needed.
+# Clients connect to http://<host>:8765/mcp (Streamable HTTP transport).
+CMD ["python3", "main.py", "--transport", "streamable-http", "--host", "0.0.0.0", "--port", "8765"]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,6 +1,6 @@
-# Deploying OPNsense MCP (SSE Mode)
+# Deploying OPNsense MCP (Streamable HTTP Mode)
 
-This folder is for the centralized `SSE` deployment path.
+This folder is for the centralized `Streamable HTTP` deployment path.
 
 For local IDE usage (`STDIO`), use the root quickstart instead:
 [`../docs/GETTING_STARTED.md`](../docs/GETTING_STARTED.md).
@@ -19,13 +19,13 @@ sudo bash deploy/install.sh
 After TLS and DNS are in place, clients connect to:
 
 ```text
-https://<your-hostname>/sse
+https://<your-hostname>/mcp
 ```
 
 ## Runtime Summary
 
-- App container runs `mcp-proxy` in `SSE -> stdio` mode against `python3 main.py`.
-- App listens on HTTP `8765` inside the pod/network.
+- App container runs FastMCP natively (`python3 main.py --transport streamable-http --host 0.0.0.0 --port 8765`).
+- App listens on HTTP `8765` inside the pod/network; MCP endpoint is `/mcp` (Streamable HTTP, MCP spec 2025-03-26).
 - TLS is terminated by Caddy (`deploy/TLS.md`).
 
 ## Required Follow-ups

--- a/deploy/TLS.md
+++ b/deploy/TLS.md
@@ -1,6 +1,6 @@
 # TLS for the centralized MCP service
 
-The SSE listener run by **`mcp-proxy`** is **HTTP only** (there are no `--cert` / `--key` flags for the server side). Production HTTPS should use **TLS termination in front** of the app container.
+The FastMCP Streamable HTTP server is **HTTP only** (TLS is not configured at the application layer). Production HTTPS should use **TLS termination in front** of the app container.
 
 ## Host certificate layout (this deployment)
 
@@ -27,16 +27,16 @@ Create a **DNS A** (or **AAAA**) record so clients resolve the MCP host to the p
 
 The default **`deploy/caddyfile.example`** uses that hostname in the site block. Your certificate must include **`opnsense-mcp.freeblizz.com`** or a **wildcard** `*.freeblizz.com` that covers it.
 
-MCP clients use **`https://opnsense-mcp.freeblizz.com/sse`** (after TLS trust is satisfied).
+MCP clients use **`https://opnsense-mcp.freeblizz.com/mcp`** (after TLS trust is satisfied).
 
 ## Recommended stack
 
-1. **`opnsense-mcp-app.container`** — `mcp-proxy` + `main.py`, listens on **8765** inside the pod (reachable from Caddy on the pod network; no host **`PublishPort`** in the default pod quadlet).
+1. **`opnsense-mcp-app.container`** — FastMCP serving Streamable HTTP (`python3 main.py --transport streamable-http --host 0.0.0.0 --port 8765`), listens on **8765** inside the pod (reachable from Caddy on the pod network; no host **`PublishPort`** in the default pod quadlet). MCP endpoint is `/mcp`.
 2. **`opnsense-mcp-caddy.container`** — **Caddy** in the same pod as the app, TLS on **443**, reverse proxy to `http://127.0.0.1:8765`. Mount `/opt/certs/wild` read-only and keep **`$INSTALL_ROOT/Caddyfile`** (default **`/opt/containerdata/opnsense-mcp/Caddyfile`**) on the host, mounted into the container as `/etc/caddy/Caddyfile`.
 
 The default **`deploy/caddyfile.example`** (copied on first install) uses **manual TLS** only (`tls` with PEM paths) — **no automatic Let’s Encrypt**. The site name **`opnsense-mcp.freeblizz.com`** matches the intended DNS record; change it if you use another FQDN.
 
-Clients use **`https://opnsense-mcp.freeblizz.com/sse`** (or your edited hostname), with trust depending on your cert (wildcard/SAN).
+Clients use **`https://opnsense-mcp.freeblizz.com/mcp`** (or your edited hostname), with trust depending on your cert (wildcard/SAN).
 
 
 ## Operations

--- a/deploy/caddyfile.example
+++ b/deploy/caddyfile.example
@@ -1,4 +1,4 @@
-# OPNsense MCP — Caddy terminates TLS; mcp-proxy serves MCP (SSE) at http://127.0.0.1:8765 in the same pod.
+# OPNsense MCP — Caddy terminates TLS; FastMCP serves Streamable HTTP at http://127.0.0.1:8765/mcp in the same pod.
 #
 # Install copies this to $OPNSENSE_MCP_INSTALL_ROOT/Caddyfile (e.g. /opt/containerdata/opnsense-mcp/Caddyfile).
 # PEM paths must exist on the host and match OPNSENSE_MCP_TLS_CERTS (default: /opt/certs/wild).

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,4 +1,5 @@
 # Docker Compose (Linux amd64). TLS: Caddy terminates HTTPS; MCP is HTTP on loopback.
+# MCP endpoint: http://localhost:8765/mcp (Streamable HTTP, MCP spec 2025-03-26)
 # Used by deploy/install.sh --runtime docker. Copy or run from a checkout of this repo.
 
 services:

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -171,7 +171,7 @@ write_opnsense_mcp_quadlet() {
   local pod_quadlet_file=$3
   {
     printf '%s\n' '[Unit]'
-    printf '%s\n' 'Description=OPNsense MCP (Podman quadlet, mcp-proxy SSE)'
+    printf '%s\n' 'Description=OPNsense MCP (Podman quadlet, FastMCP Streamable HTTP)'
     printf '%s\n' "After=network-online.target ${pod_svc}"
     printf '%s\n' 'Wants=network-online.target'
     printf '%s\n' "Requires=${pod_svc}"

--- a/deploy/opnsense-mcp-app.container.example
+++ b/deploy/opnsense-mcp-app.container.example
@@ -1,9 +1,9 @@
-# Podman quadlet: OPNsense MCP app (mcp-proxy SSE on 8765).
+# Podman quadlet: OPNsense MCP app (FastMCP Streamable HTTP on 8765).
 # Used inside a pod (see opnsense-mcp.pod.example); Pod= references the .pod filename.
 # Quadlet unit: opnsense-mcp-app.service. Pod unit: opnsense-mcp-pod.service (from opnsense-mcp.pod).
 
 [Unit]
-Description=OPNsense MCP (Podman quadlet, mcp-proxy SSE)
+Description=OPNsense MCP (Podman quadlet, FastMCP Streamable HTTP)
 After=network-online.target opnsense-mcp-pod.service
 Wants=network-online.target
 Requires=opnsense-mcp-pod.service

--- a/deploy/opnsense-mcp.pod.example
+++ b/deploy/opnsense-mcp.pod.example
@@ -16,7 +16,7 @@ PodName=opnsense-mcp-pod
 # IP6=2601:441:8400:b7e1::50
 # DNS=10.0.2.2
 # DNS=10.0.10.4
-# No PublishPort: with macvlan (or similar) the pod has its own IP; Caddy :443 and mcp-proxy :8765 bind on the pod network.
+# No PublishPort: with macvlan (or similar) the pod has its own IP; Caddy :443 and FastMCP :8765 bind on the pod network.
 
 [Service]
 Restart=on-failure

--- a/main.py
+++ b/main.py
@@ -9,7 +9,6 @@ It redirects to the actual MCP server implementation in opnsense_mcp.server.
 import argparse
 import os
 
-from opnsense_mcp.server import main as mcp_main
 from opnsense_mcp.utils.logging import setup_logging
 
 
@@ -17,8 +16,7 @@ def main() -> None:
     """
     Start the OPNsense MCP Server.
 
-    This function parses command line arguments and starts the MCP server.
-    The server communicates over stdio using the Model Context Protocol.
+    Supports stdio (default) and streamable-http transports.
     """
     parser = argparse.ArgumentParser(description="OPNsense MCP Server")
     parser.add_argument("--log-file", type=str, help="Path to log file (optional)")
@@ -29,27 +27,53 @@ def main() -> None:
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
         help="Logging level",
     )
+    parser.add_argument(
+        "--transport",
+        type=str,
+        default="stdio",
+        choices=["stdio", "streamable-http", "http", "sse"],
+        help="MCP transport protocol (default: stdio)",
+    )
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="0.0.0.0",
+        help="Host to bind for HTTP transport (default: 0.0.0.0)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8765,
+        help="Port to bind for HTTP transport (default: 8765)",
+    )
 
     args = parser.parse_args()
 
-    # Setup logging
     setup_logging(args.log_file, args.log_level)
 
-    # Set environment variable for JWT secret key if not set
     if not os.environ.get("MCP_SECRET_KEY"):
-        # NOTE: Hardcoded secret key for development only. Change in production!
-        # Bandit: # nosec
         os.environ["MCP_SECRET_KEY"] = (
             "development-secret-key"  # pragma: allowlist secret
         )
 
-    # Set up MCP environment
     os.environ["PYTHONUNBUFFERED"] = "1"
     os.environ["PYTHONIOENCODING"] = "utf-8"
-    os.environ["MCP_TRANSPORT"] = "stdio"
 
-    # Run the MCP server
-    mcp_main()
+    if args.transport == "stdio":
+        os.environ["MCP_TRANSPORT"] = "stdio"
+        from opnsense_mcp.server import main as mcp_main
+
+        mcp_main()
+    else:
+        from opnsense_mcp.fastmcp_server import build_mcp_server
+
+        mcp = build_mcp_server()
+        mcp.run(
+            transport=args.transport,
+            host=args.host,
+            port=args.port,
+            show_banner=False,
+        )
 
 
 if __name__ == "__main__":

--- a/opnsense_mcp/fastmcp_server.py
+++ b/opnsense_mcp/fastmcp_server.py
@@ -444,13 +444,9 @@ def build_mcp_server() -> FastMCP:
         protocol: str | None = None,
     ) -> str:
         """Get firewall logs with optional filtering."""
-        logs = await firewall_logs_tool.get_logs(
-            limit=limit,
-            action=action,
-            src_ip=src_ip,
-            dst_ip=dst_ip,
-            protocol=protocol,
+        result = await firewall_logs_tool.execute(
+            {"limit": limit, "action": action, "src_ip": src_ip, "dst_ip": dst_ip, "protocol": protocol}
         )
-        return str(logs)
+        return str(result)
 
     return mcp

--- a/opnsense_mcp/fastmcp_server.py
+++ b/opnsense_mcp/fastmcp_server.py
@@ -1,0 +1,456 @@
+# opnsense_mcp/fastmcp_server.py
+"""FastMCP-based server supporting Streamable HTTP, SSE, and stdio transports."""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+from opnsense_mcp.server import get_opnsense_client
+from opnsense_mcp.tools.aliases import AliasesTool
+from opnsense_mcp.tools.arp import ARPTool
+from opnsense_mcp.tools.dhcp import DHCPTool
+from opnsense_mcp.tools.dhcp_host_move import MoveDhcpHostTool
+from opnsense_mcp.tools.dhcp_hosts import ListDhcpHostsTool
+from opnsense_mcp.tools.dhcp_lease_delete import DHCPLeaseDeleteTool
+from opnsense_mcp.tools.dhcp_subnet_dns import (
+    ListDhcpSubnetDnsTool,
+    SetDhcpSubnetDnsTool,
+)
+from opnsense_mcp.tools.dns import DNSTool
+from opnsense_mcp.tools.firewall_logs import FirewallLogsTool
+from opnsense_mcp.tools.flush_dns import FlushDnsTool
+from opnsense_mcp.tools.fw_rules import FwRulesTool
+from opnsense_mcp.tools.gateway_status import GatewayStatusTool
+from opnsense_mcp.tools.interface_list import InterfaceListTool
+from opnsense_mcp.tools.lldp import LLDPTool
+from opnsense_mcp.tools.mk_dhcp_host import MkDhcpHostTool
+from opnsense_mcp.tools.mkdns import MkdnsTool
+from opnsense_mcp.tools.mkfw_rule import MkfwRuleTool
+from opnsense_mcp.tools.packet_capture import PacketCaptureTool2 as PacketCaptureTool
+from opnsense_mcp.tools.rm_dhcp_host import RmDhcpHostTool
+from opnsense_mcp.tools.rmdns import RmdnsTool
+from opnsense_mcp.tools.rmfw_rule import RmfwRuleTool
+from opnsense_mcp.tools.set_fw_rule import SetFwRuleTool
+from opnsense_mcp.tools.ssh_fw_rule import SSHFirewallRuleTool
+from opnsense_mcp.tools.system import SystemTool
+from opnsense_mcp.tools.toggle_fw_rule import ToggleFwRuleTool
+from opnsense_mcp.utils.env import load_opnsense_env
+
+
+def build_mcp_server() -> FastMCP:
+    """Build and return a configured FastMCP server with all OPNsense tools registered."""
+    load_opnsense_env()
+
+    client = get_opnsense_client({})
+
+    arp_tool = ARPTool(client)
+    dhcp_tool = DHCPTool(client)
+    dhcp_lease_delete_tool = DHCPLeaseDeleteTool(client)
+    list_dhcp_subnet_dns_tool = ListDhcpSubnetDnsTool(client)
+    set_dhcp_subnet_dns_tool = SetDhcpSubnetDnsTool(client)
+    move_dhcp_host_tool = MoveDhcpHostTool(client)
+    list_dhcp_hosts_tool = ListDhcpHostsTool(client)
+    rm_dhcp_host_tool = RmDhcpHostTool(client)
+    mk_dhcp_host_tool = MkDhcpHostTool(client)
+    lldp_tool = LLDPTool(client)
+    system_tool = SystemTool(client)
+    fw_rules_tool = FwRulesTool(client)
+    mkfw_rule_tool = MkfwRuleTool(client)
+    rmfw_rule_tool = RmfwRuleTool(client)
+    interface_list_tool = InterfaceListTool(client)
+    packet_capture_tool = PacketCaptureTool()
+    ssh_fw_rule_tool = SSHFirewallRuleTool(client)
+    dns_tool = DNSTool(client)
+    mkdns_tool = MkdnsTool(client)
+    rmdns_tool = RmdnsTool(client)
+    flush_dns_tool = FlushDnsTool(client)
+    toggle_fw_rule_tool = ToggleFwRuleTool(client)
+    set_fw_rule_tool = SetFwRuleTool(client)
+    aliases_tool = AliasesTool(client)
+    gateway_status_tool = GatewayStatusTool(client)
+    firewall_logs_tool = FirewallLogsTool(client)
+
+    mcp = FastMCP("opnsense-mcp")
+
+    @mcp.tool()
+    async def arp(
+        mac: str | None = None,
+        ip: str | None = None,
+        search: str | None = None,
+    ) -> str:
+        """Show ARP/NDP table."""
+        result = await arp_tool.execute({"mac": mac, "ip": ip, "search": search})
+        return str(result)
+
+    @mcp.tool()
+    async def dhcp(search: str | None = None) -> str:
+        """Show DHCP lease information."""
+        result = await dhcp_tool.execute({"search": search})
+        return str(result)
+
+    @mcp.tool()
+    async def dhcp_lease_delete(
+        hostname: str | None = None,
+        ip: str | None = None,
+        mac: str | None = None,
+    ) -> str:
+        """Delete DHCP leases by hostname, IP, or MAC address."""
+        result = await dhcp_lease_delete_tool.execute(
+            {"hostname": hostname, "ip": ip, "mac": mac}
+        )
+        return str(result)
+
+    @mcp.tool()
+    async def list_dhcp_subnet_dns(
+        subnet: str | None = None,
+        interface: str | None = None,
+    ) -> str:
+        """List DHCP-provided DNS servers for a subnet scope (dnsmasq or Kea backends)."""
+        result = await list_dhcp_subnet_dns_tool.execute(
+            {"subnet": subnet, "interface": interface}
+        )
+        return str(result)
+
+    @mcp.tool()
+    async def set_dhcp_subnet_dns(
+        family: str,
+        subnet: str | None = None,
+        interface: str | None = None,
+        dns_server: str | None = None,
+        dns_servers: list[str] | None = None,
+        slot: int | None = None,
+    ) -> str:
+        """Set DHCP-provided DNS servers for a subnet scope."""
+        result = await set_dhcp_subnet_dns_tool.execute(
+            {
+                "family": family,
+                "subnet": subnet,
+                "interface": interface,
+                "dns_server": dns_server,
+                "dns_servers": dns_servers,
+                "slot": slot,
+            }
+        )
+        return str(result)
+
+    @mcp.tool()
+    async def move_dhcp_host(
+        host: str,
+        ipv4: str | None = None,
+        ipv6: str | None = None,
+        new_hostname: str | None = None,
+        apply: bool = False,
+    ) -> str:
+        """Move a DHCP host reservation to a different subnet."""
+        result = await move_dhcp_host_tool.execute(
+            {
+                "host": host,
+                "ipv4": ipv4,
+                "ipv6": ipv6,
+                "new_hostname": new_hostname,
+                "apply": apply,
+            }
+        )
+        return str(result)
+
+    @mcp.tool()
+    async def list_dhcp_hosts(
+        search: str | None = None,
+        descr: str | None = None,
+        missing_ipv6: bool = False,
+    ) -> str:
+        """List DHCP static host reservations (dnsmasq)."""
+        result = await list_dhcp_hosts_tool.execute(
+            {"search": search, "descr": descr, "missing_ipv6": missing_ipv6}
+        )
+        return str(result)
+
+    @mcp.tool()
+    async def rm_dhcp_host(host: str, apply: bool = False) -> str:
+        """Remove a DHCP static host reservation (dnsmasq)."""
+        result = await rm_dhcp_host_tool.execute({"host": host, "apply": apply})
+        return str(result)
+
+    @mcp.tool()
+    async def mk_dhcp_host(
+        hostname: str,
+        mac: str,
+        ipv4: str | None = None,
+        ipv6: str | None = None,
+        descr: str = "",
+        domain: str = "",
+        apply: bool = False,
+    ) -> str:
+        """Create a DHCP static host reservation (dnsmasq)."""
+        result = await mk_dhcp_host_tool.execute(
+            {
+                "hostname": hostname,
+                "mac": mac,
+                "ipv4": ipv4,
+                "ipv6": ipv6,
+                "descr": descr,
+                "domain": domain,
+                "apply": apply,
+            }
+        )
+        return str(result)
+
+    @mcp.tool()
+    async def lldp() -> str:
+        """Show LLDP neighbor table."""
+        result = await lldp_tool.execute({})
+        return str(result)
+
+    @mcp.tool()
+    async def system() -> str:
+        """Show system status information."""
+        result = await system_tool.execute({})
+        return str(result)
+
+    @mcp.tool()
+    async def fw_rules(
+        interface: str | None = None,
+        action: str | None = None,
+        enabled: bool | None = None,
+        protocol: str | None = None,
+    ) -> str:
+        """Get firewall rules from the OPNsense Firewall Automation API."""
+        result = await fw_rules_tool.execute(
+            {
+                "interface": interface,
+                "action": action,
+                "enabled": enabled,
+                "protocol": protocol,
+            }
+        )
+        return str(result)
+
+    @mcp.tool()
+    async def mkfw_rule(
+        description: str,
+        interface: str = "lan",
+        action: str = "pass",
+        protocol: str = "any",
+        source_net: str = "any",
+        source_port: str = "any",
+        destination_net: str = "any",
+        destination_port: str = "any",
+        direction: str = "in",
+        ipprotocol: str = "inet",
+        enabled: bool = True,
+        gateway: str = "",
+        apply: bool = True,
+    ) -> str:
+        """Create a new firewall rule and optionally apply changes."""
+        result = await mkfw_rule_tool.execute(
+            {
+                "description": description,
+                "interface": interface,
+                "action": action,
+                "protocol": protocol,
+                "source_net": source_net,
+                "source_port": source_port,
+                "destination_net": destination_net,
+                "destination_port": destination_port,
+                "direction": direction,
+                "ipprotocol": ipprotocol,
+                "enabled": enabled,
+                "gateway": gateway,
+                "apply": apply,
+            }
+        )
+        return str(result)
+
+    @mcp.tool()
+    async def rmfw_rule(rule_uuid: str, apply: bool = True) -> str:
+        """Delete a firewall rule and optionally apply changes."""
+        result = await rmfw_rule_tool.execute({"rule_uuid": rule_uuid, "apply": apply})
+        return str(result)
+
+    @mcp.tool()
+    async def ssh_fw_rule(
+        description: str,
+        interface: str = "lan",
+        action: str = "block",
+        protocol: str = "any",
+        source_net: str = "any",
+        source_port: str = "any",
+        destination_net: str = "any",
+        destination_port: str = "any",
+        direction: str = "in",
+        ipprotocol: str = "inet",
+        enabled: bool = True,
+        apply: bool = True,
+    ) -> str:
+        """Create firewall rules via SSH (bypasses API issues)."""
+        result = await ssh_fw_rule_tool.execute(
+            {
+                "description": description,
+                "interface": interface,
+                "action": action,
+                "protocol": protocol,
+                "source_net": source_net,
+                "source_port": source_port,
+                "destination_net": destination_net,
+                "destination_port": destination_port,
+                "direction": direction,
+                "ipprotocol": ipprotocol,
+                "enabled": enabled,
+                "apply": apply,
+            }
+        )
+        return str(result)
+
+    @mcp.tool()
+    async def interface_list() -> str:
+        """Get available interface names for firewall rules."""
+        result = await interface_list_tool.execute({})
+        return str(result)
+
+    @mcp.tool()
+    async def packet_capture(
+        action: str = "start",
+        interface: str = "wan",
+        filter: str | None = None,
+        duration: int = 30,
+        count: int | None = None,
+        local_path: str | None = None,
+        raw: bool = False,
+        stream: bool = False,
+        preview_bytes: int = 1000,
+    ) -> str:
+        """Start, stop, or fetch a packet capture file."""
+        result = await packet_capture_tool.execute(
+            {
+                "action": action,
+                "interface": interface,
+                "filter": filter,
+                "duration": duration,
+                "count": count,
+                "local_path": local_path,
+                "raw": raw,
+                "stream": stream,
+                "preview_bytes": preview_bytes,
+            }
+        )
+        return str(result)
+
+    @mcp.tool()
+    async def dns(search: str | None = None) -> str:
+        """List Unbound DNS host overrides."""
+        result = await dns_tool.execute({"search": search})
+        return str(result)
+
+    @mcp.tool()
+    async def mkdns(
+        hostname: str,
+        domain: str,
+        server: str,
+        description: str = "",
+        enabled: bool = True,
+    ) -> str:
+        """Add a DNS host override in Unbound."""
+        result = await mkdns_tool.execute(
+            {
+                "hostname": hostname,
+                "domain": domain,
+                "server": server,
+                "description": description,
+                "enabled": enabled,
+            }
+        )
+        return str(result)
+
+    @mcp.tool()
+    async def rmdns(uuid: str) -> str:
+        """Delete a DNS host override from Unbound."""
+        result = await rmdns_tool.execute({"uuid": uuid})
+        return str(result)
+
+    @mcp.tool()
+    async def flush_dns(hostname: str | None = None, mode: str = "name") -> str:
+        """Flush Unbound DNS cache for a hostname or restart Unbound."""
+        result = await flush_dns_tool.execute({"hostname": hostname, "mode": mode})
+        return str(result)
+
+    @mcp.tool()
+    async def toggle_fw_rule(
+        rule_uuid: str,
+        enabled: bool,
+        apply: bool = True,
+    ) -> str:
+        """Enable or disable a firewall rule."""
+        result = await toggle_fw_rule_tool.execute(
+            {"rule_uuid": rule_uuid, "enabled": enabled, "apply": apply}
+        )
+        return str(result)
+
+    @mcp.tool()
+    async def set_fw_rule(
+        rule_uuid: str,
+        description: str | None = None,
+        interface: str | None = None,
+        direction: str | None = None,
+        ipprotocol: str | None = None,
+        protocol: str | None = None,
+        source_net: str | None = None,
+        source_port: str | None = None,
+        destination_net: str | None = None,
+        destination_port: str | None = None,
+        action: str | None = None,
+        enabled: bool | None = None,
+        gateway: str | None = None,
+        apply: bool = True,
+    ) -> str:
+        """Edit fields of an existing firewall rule."""
+        result = await set_fw_rule_tool.execute(
+            {
+                "rule_uuid": rule_uuid,
+                "description": description,
+                "interface": interface,
+                "direction": direction,
+                "ipprotocol": ipprotocol,
+                "protocol": protocol,
+                "source_net": source_net,
+                "source_port": source_port,
+                "destination_net": destination_net,
+                "destination_port": destination_port,
+                "action": action,
+                "enabled": enabled,
+                "gateway": gateway,
+                "apply": apply,
+            }
+        )
+        return str(result)
+
+    @mcp.tool()
+    async def aliases(search: str | None = None) -> str:
+        """List firewall aliases (IP groups, port groups, etc)."""
+        result = await aliases_tool.execute({"search": search})
+        return str(result)
+
+    @mcp.tool()
+    async def gateway_status() -> str:
+        """Show WAN gateway health (latency, packet loss)."""
+        result = await gateway_status_tool.execute({})
+        return str(result)
+
+    @mcp.tool()
+    async def get_logs(
+        limit: int = 500,
+        action: str | None = None,
+        src_ip: str | None = None,
+        dst_ip: str | None = None,
+        protocol: str | None = None,
+    ) -> str:
+        """Get firewall logs with optional filtering."""
+        logs = await firewall_logs_tool.get_logs(
+            limit=limit,
+            action=action,
+            src_ip=src_ip,
+            dst_ip=dst_ip,
+            protocol=protocol,
+        )
+        return str(logs)
+
+    return mcp

--- a/tests/test_fastmcp_server.py
+++ b/tests/test_fastmcp_server.py
@@ -1,0 +1,46 @@
+"""Tests for the FastMCP-based Streamable HTTP server."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_fastmcp_server_imports():
+    """fastmcp_server module must be importable."""
+    from opnsense_mcp.fastmcp_server import build_mcp_server
+    assert build_mcp_server is not None
+
+
+@pytest.mark.asyncio
+async def test_fastmcp_server_lists_tools():
+    """Server must expose all expected tools."""
+    from fastmcp.client import Client
+    from opnsense_mcp.fastmcp_server import build_mcp_server
+
+    mcp = build_mcp_server()
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    tool_names = {t.name for t in tools}
+    expected = {
+        "arp", "dhcp", "dhcp_lease_delete", "list_dhcp_subnet_dns",
+        "set_dhcp_subnet_dns", "move_dhcp_host", "list_dhcp_hosts",
+        "rm_dhcp_host", "mk_dhcp_host", "lldp", "system", "fw_rules",
+        "mkfw_rule", "rmfw_rule", "ssh_fw_rule", "interface_list",
+        "packet_capture", "dns", "mkdns", "rmdns", "flush_dns",
+        "toggle_fw_rule", "set_fw_rule", "aliases", "gateway_status",
+        "get_logs",
+    }
+    assert expected.issubset(tool_names), f"Missing tools: {expected - tool_names}"
+
+
+@pytest.mark.asyncio
+async def test_fastmcp_server_tool_count():
+    """Server must expose exactly 26 tools."""
+    from fastmcp.client import Client
+    from opnsense_mcp.fastmcp_server import build_mcp_server
+
+    mcp = build_mcp_server()
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    assert len(tools) == 26

--- a/tests/test_fastmcp_server.py
+++ b/tests/test_fastmcp_server.py
@@ -44,3 +44,17 @@ async def test_fastmcp_server_tool_count():
         tools = await client.list_tools()
 
     assert len(tools) == 26
+
+
+def test_main_argparser_accepts_transport():
+    """main.py argparser must accept --transport with streamable-http option."""
+    import subprocess
+    import sys
+    result = subprocess.run(
+        [sys.executable, "main.py", "--help"],
+        capture_output=True,
+        text=True,
+        cwd="/Users/corey/code/opnsense-mcp",
+    )
+    assert "--transport" in result.stdout
+    assert "streamable-http" in result.stdout

--- a/tests/test_fastmcp_server.py
+++ b/tests/test_fastmcp_server.py
@@ -14,6 +14,7 @@ async def test_fastmcp_server_imports():
 async def test_fastmcp_server_lists_tools():
     """Server must expose all expected tools."""
     from fastmcp.client import Client
+
     from opnsense_mcp.fastmcp_server import build_mcp_server
 
     mcp = build_mcp_server()
@@ -37,6 +38,7 @@ async def test_fastmcp_server_lists_tools():
 async def test_fastmcp_server_tool_count():
     """Server must expose exactly 26 tools."""
     from fastmcp.client import Client
+
     from opnsense_mcp.fastmcp_server import build_mcp_server
 
     mcp = build_mcp_server()


### PR DESCRIPTION
## Summary

- Adds native Streamable HTTP transport via FastMCP (`POST /mcp`) as an alternative to stdio
- New `opnsense_mcp/fastmcp_server.py` registers all 26 tools with FastMCP
- `main.py` gains `--transport [stdio|streamable-http|http|sse]`, `--host`, `--port` flags (stdio default, backward compatible)
- Container updated to run FastMCP directly — removes `mcp-proxy` dependency entirely
- Deploy docs updated to reference `/mcp` path and Streamable HTTP protocol

## Test Plan
- [ ] 175 tests passing locally
- [ ] Container deployed to strongpod, confirmed running on `/mcp` with FastMCP (no mcp-proxy)
- [ ] Uvicorn startup log shows `transport 'streamable-http' on http://0.0.0.0:8765/mcp`

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)