### PR TITLE
feat(dhcp): add client_id (DUID) support for host reservations

### DIFF
--- a/opnsense_mcp/fastmcp_server.py
+++ b/opnsense_mcp/fastmcp_server.py
@@ -139,6 +139,7 @@ def build_mcp_server() -> FastMCP:
         ipv4: str | None = None,
         ipv6: str | None = None,
         new_hostname: str | None = None,
+        client_id: str | None = None,
         apply: bool = False,
     ) -> str:
         """Move a DHCP host reservation to a different subnet."""
@@ -148,6 +149,7 @@ def build_mcp_server() -> FastMCP:
                 "ipv4": ipv4,
                 "ipv6": ipv6,
                 "new_hostname": new_hostname,
+                "client_id": client_id,
                 "apply": apply,
             }
         )
@@ -177,6 +179,7 @@ def build_mcp_server() -> FastMCP:
         mac: str,
         ipv4: str | None = None,
         ipv6: str | None = None,
+        client_id: str | None = None,
         descr: str = "",
         domain: str = "",
         apply: bool = False,
@@ -188,6 +191,7 @@ def build_mcp_server() -> FastMCP:
                 "mac": mac,
                 "ipv4": ipv4,
                 "ipv6": ipv6,
+                "client_id": client_id,
                 "descr": descr,
                 "domain": domain,
                 "apply": apply,
@@ -445,7 +449,13 @@ def build_mcp_server() -> FastMCP:
     ) -> str:
         """Get firewall logs with optional filtering."""
         result = await firewall_logs_tool.execute(
-            {"limit": limit, "action": action, "src_ip": src_ip, "dst_ip": dst_ip, "protocol": protocol}
+            {
+                "limit": limit,
+                "action": action,
+                "src_ip": src_ip,
+                "dst_ip": dst_ip,
+                "protocol": protocol,
+            }
         )
         return str(result)
 

--- a/opnsense_mcp/tools/dhcp_host_move.py
+++ b/opnsense_mcp/tools/dhcp_host_move.py
@@ -40,6 +40,13 @@ class MoveDhcpHostTool:
                 "type": "string",
                 "description": "New dnsmasq host reservation name (optional rename)",
             },
+            "client_id": {
+                "type": "string",
+                "description": (
+                    "Set or replace DHCP client identifier / DUID for IPv6 (e.g. "
+                    "'00:03:00:01:52:54:00:ab:cd:01'). Accepts optional 'id:' prefix."
+                ),
+            },
             "apply": {
                 "type": "boolean",
                 "description": "Apply the change. Omit/false = dry run.",
@@ -50,6 +57,7 @@ class MoveDhcpHostTool:
             {"required": ["ipv4"]},
             {"required": ["ipv6"]},
             {"required": ["new_hostname"]},
+            {"required": ["client_id"]},
         ],
     }
 
@@ -70,10 +78,16 @@ class MoveDhcpHostTool:
         ipv4 = params.get("ipv4")
         ipv6 = params.get("ipv6")
         new_hostname = params.get("new_hostname")
-        if ipv4 is None and ipv6 is None and not str(new_hostname or "").strip():
+        client_id = params.get("client_id")
+        if (
+            ipv4 is None
+            and ipv6 is None
+            and not str(new_hostname or "").strip()
+            and client_id is None
+        ):
             return {
                 "status": "error",
-                "error": "Provide ipv4, ipv6, and/or new_hostname",
+                "error": "Provide ipv4, ipv6, client_id, and/or new_hostname",
             }
 
         apply = bool(params.get("apply", False))
@@ -83,6 +97,7 @@ class MoveDhcpHostTool:
                 ipv4=ipv4,
                 ipv6=ipv6,
                 new_hostname=str(new_hostname).strip() if new_hostname else None,
+                client_id=str(client_id).strip() if client_id is not None else None,
                 dry_run=not apply,
             )
         except Exception as exc:

--- a/opnsense_mcp/tools/mk_dhcp_host.py
+++ b/opnsense_mcp/tools/mk_dhcp_host.py
@@ -19,6 +19,8 @@ class MkDhcpHostTool:
         "Create a DHCP host reservation in the dnsmasq host table "
         "(Services → DHCPv4 → Hosts). Requires hostname and MAC; at least one "
         "of ipv4 or ipv6 suffix must be provided. "
+        "Optional client_id (DUID) improves stateful DHCPv6 matching when MAC "
+        "alone is insufficient — copy from the dhcp tool v6 lease client_id. "
         "Defaults to a dry run; pass apply=true to write and reconfigure dnsmasq."
     )
     input_schema = {
@@ -39,6 +41,13 @@ class MkDhcpHostTool:
             "ipv6": {
                 "type": ["integer", "string"],
                 "description": "IPv6 suffix: integer (e.g. 50 → ::50) or '::abcd'",
+            },
+            "client_id": {
+                "type": "string",
+                "description": (
+                    "Optional DHCP client identifier / DUID for IPv6 (e.g. "
+                    "'00:03:00:01:52:54:00:ab:cd:01'). Accepts optional 'id:' prefix."
+                ),
             },
             "descr": {
                 "type": "string",
@@ -83,6 +92,7 @@ class MkDhcpHostTool:
         if ipv4 is None and ipv6 is None:
             return {"status": "error", "error": "Provide ipv4 and/or ipv6"}
 
+        client_id = params.get("client_id")
         descr = str(params.get("descr") or "").strip()
         domain = str(params.get("domain") or "").strip()
         apply = bool(params.get("apply", False))
@@ -93,6 +103,7 @@ class MkDhcpHostTool:
                 mac=mac,
                 ipv4=str(ipv4).strip() if ipv4 is not None else None,
                 ipv6=ipv6,
+                client_id=str(client_id).strip() if client_id is not None else None,
                 descr=descr,
                 domain=domain,
                 dry_run=not apply,

--- a/opnsense_mcp/utils/api.py
+++ b/opnsense_mcp/utils/api.py
@@ -916,6 +916,7 @@ class OPNsenseClient:
         ipv4: int | str | None = None,
         ipv6: int | str | None = None,
         new_hostname: str | None = None,
+        client_id: str | None = None,
         dry_run: bool = True,
     ) -> dict[str, Any]:
         """Move/rename a DHCP host reservation (dnsmasq only)."""
@@ -928,6 +929,7 @@ class OPNsenseClient:
             ipv4_target=ipv4,
             ipv6_target=ipv6,
             new_hostname=new_hostname,
+            client_id=client_id,
             dry_run=dry_run,
         )
 
@@ -959,6 +961,7 @@ class OPNsenseClient:
         mac: str,
         ipv4: str | None = None,
         ipv6: int | str | None = None,
+        client_id: str | None = None,
         descr: str = "",
         domain: str = "",
         dry_run: bool = True,
@@ -973,6 +976,7 @@ class OPNsenseClient:
             mac=mac,
             ipv4=ipv4,
             ipv6=ipv6,
+            client_id=client_id,
             descr=descr,
             domain=domain,
             dry_run=dry_run,

--- a/opnsense_mcp/utils/dhcp_host.py
+++ b/opnsense_mcp/utils/dhcp_host.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import ipaddress
+import re
 from dataclasses import dataclass, field
 from typing import Any
+
+_CLIENT_ID_RE = re.compile(r"^([0-9a-f]{2}:)+[0-9a-f]{2}$", re.IGNORECASE)
 
 # Fields preserved verbatim when rewriting a host record back to the API.
 _PASSTHROUGH_FIELDS = (
@@ -46,6 +49,26 @@ def format_ip_field(ipv4: str | None, ipv6: str | None) -> str:
     """Join (ipv4, ipv6) back into a dnsmasq ``ip`` field, v4 first."""
     parts = [p for p in (ipv4, ipv6) if p]
     return ",".join(parts)
+
+
+def normalize_client_id(value: str | None) -> str:
+    """Return a lowercase colon-separated DHCP client identifier (DUID).
+
+    Accepts dnsmasq ``id:`` prefixes; empty/whitespace returns ``""``.
+    """
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    if raw.lower().startswith("id:"):
+        raw = raw[3:].strip()
+    normalized = raw.lower().replace("-", ":")
+    if not _CLIENT_ID_RE.match(normalized):
+        msg = (
+            "Invalid client_id; expected colon-separated hex bytes "
+            f"(DUID), got {value!r}"
+        )
+        raise ValueError(msg)
+    return normalized
 
 
 @dataclass
@@ -132,6 +155,7 @@ def flatten_host_for_write(
     *,
     new_ipv4: str | None,
     new_ipv6: str | None,
+    new_client_id: str | None = None,
 ) -> dict[str, Any]:
     """Build a flat host payload (inner object for ``{"host": ...}``) preserving
     all original fields and replacing only the ``ip`` field.
@@ -140,6 +164,8 @@ def flatten_host_for_write(
         key: str(record.raw.get(key, "") or "") for key in _PASSTHROUGH_FIELDS
     }
     payload["ip"] = format_ip_field(new_ipv4, new_ipv6)
+    if new_client_id is not None:
+        payload["client_id"] = new_client_id
     return payload
 
 
@@ -149,11 +175,15 @@ def find_ipv4_conflicts(
     moving_uuid: str,
     hosts: list[dict[str, Any]],
     leases: list[dict[str, Any]],
+    promoting_mac: str = "",
 ) -> list[dict[str, Any]]:
     """Return conflicts for ``target_ipv4``: other reservations or active leases
     already holding the address. The host being moved (``moving_uuid``) is ignored.
+    When ``promoting_mac`` is set, active leases on ``target_ipv4`` for that MAC
+    are allowed (dynamic → static promotion).
     """
     conflicts: list[dict[str, Any]] = []
+    promote = promoting_mac.strip().lower()
     for row in hosts:
         if str(row.get("uuid") or "") == moving_uuid:
             continue
@@ -169,13 +199,17 @@ def find_ipv4_conflicts(
             )
     for lease in leases:
         addr = str(lease.get("address") or lease.get("ip") or "")
-        if addr == target_ipv4:
-            conflicts.append(
-                {
-                    "kind": "lease",
-                    "address": target_ipv4,
-                    "hostname": str(lease.get("hostname") or ""),
-                    "hwaddr": str(lease.get("hwaddr") or ""),
-                }
-            )
+        if addr != target_ipv4:
+            continue
+        lease_mac = str(lease.get("hwaddr") or "").lower()
+        if promote and lease_mac == promote:
+            continue
+        conflicts.append(
+            {
+                "kind": "lease",
+                "address": target_ipv4,
+                "hostname": str(lease.get("hostname") or ""),
+                "hwaddr": lease_mac,
+            }
+        )
     return conflicts

--- a/opnsense_mcp/utils/dhcp_providers/dnsmasq.py
+++ b/opnsense_mcp/utils/dhcp_providers/dnsmasq.py
@@ -1,5 +1,6 @@
 """dnsmasq DHCP provider for OPNsense."""
 
+import ipaddress
 import logging
 import re
 from collections.abc import Callable, Coroutine
@@ -12,6 +13,7 @@ from opnsense_mcp.utils.dhcp_host import (
     find_ipv4_conflicts,
     flatten_host_for_write,
     format_ip_field,
+    normalize_client_id,
     parse_ip_field,
 )
 from opnsense_mcp.utils.dhcp_scope import resolve_scope_from_selectors
@@ -243,9 +245,9 @@ class DnsmasqProvider:
         payload: dict[str, Any] = {
             "uuid": str(row.get("uuid") or ""),
             "type": str(row.get("type") or "set"),
-            "interface": ""
-            if use_tag
-            else str(row.get("interface") or scope.interface),
+            "interface": (
+                "" if use_tag else str(row.get("interface") or scope.interface)
+            ),
             "tag": use_tag,
             "set_tag": str(row.get("set_tag") or ""),
             "value": value,
@@ -525,6 +527,7 @@ class DnsmasqProvider:
         ipv4_target: int | str | None,
         ipv6_target: int | str | None,
         new_hostname: str | None = None,
+        client_id: str | None = None,
         dry_run: bool = True,
     ) -> dict[str, Any]:
         """Move a host reservation to new v4 and/or v6 addresses."""
@@ -539,12 +542,20 @@ class DnsmasqProvider:
         new_ipv4 = rec.ipv4
         new_ipv6 = rec.ipv6_suffix
         if ipv4_target is not None:
-            if not rec.ipv4:
-                return {
-                    "status": "error",
-                    "error": f"{rec.host} has no IPv4 reservation to move",
-                }
-            new_ipv4 = apply_v4_suffix(rec.ipv4, ipv4_target)
+            if rec.ipv4:
+                new_ipv4 = apply_v4_suffix(rec.ipv4, ipv4_target)
+            else:
+                raw = str(ipv4_target).strip()
+                if "." in raw:
+                    new_ipv4 = str(ipaddress.ip_address(raw))
+                else:
+                    return {
+                        "status": "error",
+                        "error": (
+                            f"{rec.host} has no IPv4 reservation; "
+                            "provide a full address (e.g. 10.0.3.13)"
+                        ),
+                    }
         if ipv6_target is not None:
             new_ipv6 = apply_v6_suffix(ipv6_target)
 
@@ -558,10 +569,24 @@ class DnsmasqProvider:
                 }
             new_host = stripped
 
+        current_client_id = normalize_client_id(str(rec.raw.get("client_id") or ""))
+        new_client_id = current_client_id
+        if client_id is not None:
+            try:
+                new_client_id = normalize_client_id(client_id)
+            except ValueError as exc:
+                return {"status": "error", "error": str(exc)}
+
+        raw_ip = str(rec.raw.get("ip") or "")
+        canonical_ip = format_ip_field(new_ipv4, new_ipv6)
+        needs_ip_rewrite = bool(canonical_ip and raw_ip != canonical_ip)
+
         if (
             new_ipv4 == rec.ipv4
             and new_ipv6 == rec.ipv6_suffix
             and new_host == rec.host
+            and new_client_id == current_client_id
+            and not needs_ip_rewrite
         ):
             return {
                 "status": "noop",
@@ -585,19 +610,41 @@ class DnsmasqProvider:
                 hosts=all_hosts,
                 leases=leases,
             )
+        if new_client_id and new_client_id != current_client_id:
+            for row in all_hosts:
+                if str(row.get("uuid") or "") == rec.uuid:
+                    continue
+                existing = normalize_client_id(str(row.get("client_id") or ""))
+                if existing and existing == new_client_id:
+                    conflicts.append(
+                        {
+                            "kind": "reservation",
+                            "reason": "duplicate client_id",
+                            "host": str(row.get("host") or ""),
+                            "client_id": new_client_id,
+                            "uuid": str(row.get("uuid") or ""),
+                        }
+                    )
 
         planned = {
             "host": rec.host,
             "hwaddr": rec.hwaddr,
-            "hostname": {"from": rec.host, "to": new_host}
-            if new_host != rec.host
-            else None,
-            "ipv4": {"from": rec.ipv4, "to": new_ipv4}
-            if new_ipv4 != rec.ipv4
-            else None,
-            "ipv6": {"from": rec.ipv6_suffix, "to": new_ipv6}
-            if new_ipv6 != rec.ipv6_suffix
-            else None,
+            "hostname": (
+                {"from": rec.host, "to": new_host} if new_host != rec.host else None
+            ),
+            "ipv4": (
+                {"from": rec.ipv4, "to": new_ipv4} if new_ipv4 != rec.ipv4 else None
+            ),
+            "ipv6": (
+                {"from": rec.ipv6_suffix, "to": new_ipv6}
+                if new_ipv6 != rec.ipv6_suffix
+                else None
+            ),
+            "client_id": (
+                {"from": current_client_id or None, "to": new_client_id or None}
+                if new_client_id != current_client_id
+                else None
+            ),
         }
 
         if conflicts:
@@ -619,7 +666,12 @@ class DnsmasqProvider:
         original_payload = flatten_host_for_write(
             rec, new_ipv4=rec.ipv4, new_ipv6=rec.ipv6_suffix
         )
-        new_payload = flatten_host_for_write(rec, new_ipv4=new_ipv4, new_ipv6=new_ipv6)
+        new_payload = flatten_host_for_write(
+            rec,
+            new_ipv4=new_ipv4,
+            new_ipv6=new_ipv6,
+            new_client_id=new_client_id,
+        )
         if new_host != rec.host:
             new_payload["host"] = new_host
         try:
@@ -660,6 +712,7 @@ class DnsmasqProvider:
         mac: str,
         ipv4: str | None = None,
         ipv6: int | str | None = None,
+        client_id: str | None = None,
         descr: str = "",
         domain: str = "",
         dry_run: bool = True,
@@ -678,9 +731,13 @@ class DnsmasqProvider:
             raw = str(ipv4).strip()
             try:
                 import ipaddress as _ipaddress
+
                 addr = _ipaddress.ip_address(raw)
                 if addr.version != 4:
-                    return {"status": "error", "error": f"Expected IPv4 address, got {raw!r}"}
+                    return {
+                        "status": "error",
+                        "error": f"Expected IPv4 address, got {raw!r}",
+                    }
                 normalized_ipv4 = str(addr)
             except ValueError:
                 return {"status": "error", "error": f"Invalid IPv4 address: {raw!r}"}
@@ -693,7 +750,17 @@ class DnsmasqProvider:
                 return {"status": "error", "error": str(exc)}
 
         if normalized_ipv4 is None and normalized_ipv6 is None:
-            return {"status": "error", "error": "At least one of ipv4 or ipv6 is required"}
+            return {
+                "status": "error",
+                "error": "At least one of ipv4 or ipv6 is required",
+            }
+
+        normalized_client_id = ""
+        if client_id is not None:
+            try:
+                normalized_client_id = normalize_client_id(client_id)
+            except ValueError as exc:
+                return {"status": "error", "error": str(exc)}
 
         all_hosts = await self.list_hosts()
         leases = self._extract_leases(
@@ -707,26 +774,45 @@ class DnsmasqProvider:
         conflicts: list[dict[str, Any]] = []
         for row in all_hosts:
             if str(row.get("hwaddr") or "").lower() == normalized_mac:
-                conflicts.append({
-                    "kind": "reservation",
-                    "reason": "duplicate MAC",
-                    "host": str(row.get("host") or ""),
-                    "hwaddr": normalized_mac,
-                    "uuid": str(row.get("uuid") or ""),
-                })
+                conflicts.append(
+                    {
+                        "kind": "reservation",
+                        "reason": "duplicate MAC",
+                        "host": str(row.get("host") or ""),
+                        "hwaddr": normalized_mac,
+                        "uuid": str(row.get("uuid") or ""),
+                    }
+                )
+        if normalized_client_id:
+            for row in all_hosts:
+                existing = normalize_client_id(str(row.get("client_id") or ""))
+                if existing and existing == normalized_client_id:
+                    conflicts.append(
+                        {
+                            "kind": "reservation",
+                            "reason": "duplicate client_id",
+                            "host": str(row.get("host") or ""),
+                            "client_id": normalized_client_id,
+                            "uuid": str(row.get("uuid") or ""),
+                        }
+                    )
         if normalized_ipv4:
-            conflicts.extend(find_ipv4_conflicts(
-                target_ipv4=normalized_ipv4,
-                moving_uuid="",
-                hosts=all_hosts,
-                leases=leases,
-            ))
+            conflicts.extend(
+                find_ipv4_conflicts(
+                    target_ipv4=normalized_ipv4,
+                    moving_uuid="",
+                    hosts=all_hosts,
+                    leases=leases,
+                    promoting_mac=normalized_mac,
+                )
+            )
 
         planned = {
             "host": hostname.strip(),
             "hwaddr": normalized_mac,
             "ipv4": normalized_ipv4,
             "ipv6_suffix": normalized_ipv6,
+            "client_id": normalized_client_id or None,
             "descr": descr,
             "domain": domain,
         }
@@ -755,7 +841,7 @@ class DnsmasqProvider:
             "descr": descr,
             "local": "",
             "cnames": "",
-            "client_id": "",
+            "client_id": normalized_client_id,
             "lease_time": "",
             "ignore": "0",
             "set_tag": "",

--- a/tests/test_dhcp_host.py
+++ b/tests/test_dhcp_host.py
@@ -7,6 +7,7 @@ from opnsense_mcp.utils.dhcp_host import (
     find_ipv4_conflicts,
     flatten_host_for_write,
     format_ip_field,
+    normalize_client_id,
     parse_ip_field,
 )
 
@@ -154,6 +155,25 @@ def test_find_ipv4_conflicts_active_lease():
     assert any(c["kind"] == "lease" and c["address"] == "10.0.8.9" for c in conflicts)
 
 
+def test_find_ipv4_conflicts_allows_same_mac_promotion():
+    hosts: list[dict] = []
+    leases = [
+        {
+            "address": "10.0.3.13",
+            "hwaddr": "52:54:00:ab:cd:01",
+            "hostname": "hermes",
+        }
+    ]
+    conflicts = find_ipv4_conflicts(
+        target_ipv4="10.0.3.13",
+        moving_uuid="",
+        hosts=hosts,
+        leases=leases,
+        promoting_mac="52:54:00:ab:cd:01",
+    )
+    assert conflicts == []
+
+
 def test_find_ipv4_conflicts_none_when_free():
     hosts = [{"uuid": "u1", "host": "printer", "ip": "10.0.8.2,::2", "hwaddr": "AA"}]
     assert (
@@ -165,3 +185,45 @@ def test_find_ipv4_conflicts_none_when_free():
         )
         == []
     )
+
+
+def test_normalize_client_id_accepts_duid():
+    assert (
+        normalize_client_id("00:03:00:01:52:54:00:ab:cd:01")
+        == "00:03:00:01:52:54:00:ab:cd:01"
+    )
+
+
+def test_normalize_client_id_strips_id_prefix():
+    assert normalize_client_id("id:00:03:00:01:aa:bb:cc:dd:ee:ff") == (
+        "00:03:00:01:aa:bb:cc:dd:ee:ff"
+    )
+
+
+def test_normalize_client_id_empty():
+    assert normalize_client_id("") == ""
+    assert normalize_client_id(None) == ""
+
+
+def test_normalize_client_id_rejects_invalid():
+    with pytest.raises(ValueError, match="Invalid client_id"):
+        normalize_client_id("not-a-duid")
+
+
+def test_flatten_host_for_write_can_replace_client_id():
+    rec = DhcpHostRecord.from_row(
+        {
+            "uuid": "u1",
+            "host": "hermes",
+            "ip": "10.0.3.13,::13",
+            "hwaddr": "52:54:00:ab:cd:01",
+            "client_id": "",
+        }
+    )
+    payload = flatten_host_for_write(
+        rec,
+        new_ipv4="10.0.3.13",
+        new_ipv6="::13",
+        new_client_id="00:03:00:01:52:54:00:ab:cd:01",
+    )
+    assert payload["client_id"] == "00:03:00:01:52:54:00:ab:cd:01"

--- a/tests/test_dhcp_host_provider.py
+++ b/tests/test_dhcp_host_provider.py
@@ -330,6 +330,92 @@ async def test_move_host_noop_when_no_change():
 
 
 @pytest.mark.asyncio
+async def test_move_host_reorders_ip_field_when_v6_before_v4():
+    fake = FakeRequest(
+        {
+            "search_host": {
+                "rows": [
+                    {
+                        "uuid": "u1",
+                        "host": "hermes",
+                        "ip": "::13,10.0.3.13",
+                        "hwaddr": "52:54:00:ab:cd:01",
+                        "descr": "",
+                        "domain": "",
+                        "local": "0",
+                        "cnames": "",
+                        "client_id": "",
+                        "lease_time": "",
+                        "ignore": "0",
+                        "set_tag": "",
+                        "comments": "",
+                        "aliases": "",
+                    }
+                ],
+                "total": 1,
+            },
+            "leases/search": {"rows": []},
+            "set_host": {"result": "saved"},
+            "reconfigure": {"status": "ok"},
+        }
+    )
+    p = DnsmasqProvider(fake)
+    out = await p.move_host(
+        identifier="hermes",
+        ipv4_target="10.0.3.13",
+        ipv6_target=13,
+        dry_run=False,
+    )
+    assert out["status"] == "success"
+    set_calls = [c for c in fake.calls if "set_host" in c[1]]
+    assert len(set_calls) == 1
+    assert set_calls[0][2]["json"]["host"]["ip"] == "10.0.3.13,::13"
+
+
+@pytest.mark.asyncio
+async def test_move_host_can_set_client_id_only():
+    fake = FakeRequest(
+        {
+            "search_host": {
+                "rows": [
+                    {
+                        "uuid": "u1",
+                        "host": "hermes",
+                        "ip": "10.0.3.13,::13",
+                        "hwaddr": "52:54:00:ab:cd:01",
+                        "client_id": "",
+                        "descr": "",
+                        "domain": "",
+                        "local": "0",
+                        "cnames": "",
+                        "lease_time": "",
+                        "ignore": "0",
+                        "set_tag": "",
+                        "comments": "",
+                        "aliases": "",
+                    }
+                ],
+                "total": 1,
+            },
+            "leases/search": {"rows": []},
+            "set_host": {"result": "saved"},
+            "reconfigure": {"status": "ok"},
+        }
+    )
+    p = DnsmasqProvider(fake)
+    out = await p.move_host(
+        identifier="hermes",
+        ipv4_target=None,
+        ipv6_target=None,
+        client_id="00:03:00:01:52:54:00:ab:cd:01",
+        dry_run=False,
+    )
+    assert out["status"] == "success"
+    set_call = next(c for c in fake.calls if "set_host" in c[1])
+    assert set_call[2]["json"]["host"]["client_id"] == "00:03:00:01:52:54:00:ab:cd:01"
+
+
+@pytest.mark.asyncio
 async def test_move_host_not_found_returns_error():
     fake = FakeRequest({"search_host": {"rows": [], "total": 0}})
     p = DnsmasqProvider(fake)

--- a/tests/test_dhcp_providers/test_dnsmasq_create_host.py
+++ b/tests/test_dhcp_providers/test_dnsmasq_create_host.py
@@ -7,6 +7,7 @@ from opnsense_mcp.utils.dhcp_providers.dnsmasq import DnsmasqProvider
 
 def _make_provider(responses: dict):
     """Return a DnsmasqProvider backed by a fake request function."""
+
     async def fake_request(method, endpoint, **kwargs):
         return responses.get(endpoint, {})
 
@@ -179,6 +180,60 @@ async def test_ipv6_only_dry_run():
     assert result["status"] == "dry_run"
     assert result["planned"]["ipv6_suffix"] == "::50"
     assert result["planned"]["ipv4"] is None
+
+
+@pytest.mark.asyncio
+async def test_apply_includes_client_id():
+    captured = {}
+
+    async def fake_request(method, endpoint, **kwargs):
+        if endpoint == _HOST_SEARCH_ENDPOINT:
+            return _search_response([])
+        if endpoint == _LEASE_ENDPOINT:
+            return {"rows": []}
+        if endpoint == _HOST_ADD_ENDPOINT:
+            captured["payload"] = kwargs.get("json", {}).get("host", {})
+            return {"result": "saved", "uuid": "new-uuid"}
+        return {}
+
+    provider = DnsmasqProvider(fake_request)
+    result = await provider.create_host(
+        hostname="hermes",
+        mac="52:54:00:ab:cd:01",
+        ipv4="10.0.3.13",
+        ipv6=13,
+        client_id="00:03:00:01:52:54:00:ab:cd:01",
+        dry_run=False,
+    )
+    assert result["status"] == "success"
+    assert captured["payload"]["ip"] == "10.0.3.13,::13"
+    assert captured["payload"]["client_id"] == "00:03:00:01:52:54:00:ab:cd:01"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_client_id_blocked():
+    existing = {
+        **_EXISTING_ROW,
+        "client_id": "00:03:00:01:52:54:00:ab:cd:01",
+    }
+
+    async def fake_request(method, endpoint, **kwargs):
+        if endpoint == _HOST_SEARCH_ENDPOINT:
+            return _search_response([existing])
+        if endpoint == _LEASE_ENDPOINT:
+            return {"rows": []}
+        return {}
+
+    provider = DnsmasqProvider(fake_request)
+    result = await provider.create_host(
+        hostname="newhost",
+        mac="aa:bb:cc:dd:ee:ff",
+        ipv4="10.0.8.50",
+        client_id="00:03:00:01:52:54:00:ab:cd:01",
+        dry_run=False,
+    )
+    assert result["status"] == "error"
+    assert any(c["reason"] == "duplicate client_id" for c in result["conflicts"])
 
 
 @pytest.mark.asyncio

--- a/tests/test_fastmcp_server.py
+++ b/tests/test_fastmcp_server.py
@@ -52,11 +52,12 @@ def test_main_argparser_accepts_transport():
     """main.py argparser must accept --transport with streamable-http option."""
     import subprocess
     import sys
+    from pathlib import Path
     result = subprocess.run(
         [sys.executable, "main.py", "--help"],
         capture_output=True,
         text=True,
-        cwd="/Users/corey/code/opnsense-mcp",
+        cwd=str(Path(__file__).parent.parent),
     )
     assert "--transport" in result.stdout
     assert "streamable-http" in result.stdout

--- a/tests/test_mk_dhcp_host_tool.py
+++ b/tests/test_mk_dhcp_host_tool.py
@@ -55,7 +55,12 @@ async def test_tool_passes_apply_flag():
     client = FakeClient({"status": "success", "created": {}})
     tool = MkDhcpHostTool(client)
     await tool.execute(
-        {"hostname": "myhost", "mac": "aa:bb:cc:dd:ee:ff", "ipv4": "10.0.8.50", "apply": True}
+        {
+            "hostname": "myhost",
+            "mac": "aa:bb:cc:dd:ee:ff",
+            "ipv4": "10.0.8.50",
+            "apply": True,
+        }
     )
     assert client.called["dry_run"] is False
 
@@ -65,7 +70,12 @@ async def test_tool_passes_ipv6():
     client = FakeClient()
     tool = MkDhcpHostTool(client)
     await tool.execute(
-        {"hostname": "myhost", "mac": "aa:bb:cc:dd:ee:ff", "ipv4": "10.0.8.50", "ipv6": 50}
+        {
+            "hostname": "myhost",
+            "mac": "aa:bb:cc:dd:ee:ff",
+            "ipv4": "10.0.8.50",
+            "ipv6": 50,
+        }
     )
     assert client.called["ipv6"] == 50
 
@@ -85,6 +95,22 @@ async def test_tool_passes_descr_and_domain():
     )
     assert client.called["descr"] == "test device"
     assert client.called["domain"] == "lan"
+
+
+@pytest.mark.asyncio
+async def test_tool_passes_client_id():
+    client = FakeClient()
+    tool = MkDhcpHostTool(client)
+    await tool.execute(
+        {
+            "hostname": "hermes",
+            "mac": "52:54:00:ab:cd:01",
+            "ipv4": "10.0.3.13",
+            "ipv6": 13,
+            "client_id": "00:03:00:01:52:54:00:ab:cd:01",
+        }
+    )
+    assert client.called["client_id"] == "00:03:00:01:52:54:00:ab:cd:01"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds optional `client_id` (DUID) to `mk_dhcp_host` and `move_dhcp_host` for reliable stateful DHCPv6 reservations
- Normalizes `id:` prefixes, detects duplicate DUIDs, and rewrites misordered `ip` fields (`::13,10.0.3.13` → `10.0.3.13,::13`)
- Allows same-MAC lease promotion when creating static v4 reservations

## Test plan
- [x] `uv run pytest` (187 passed)
- [ ] Deploy to strongpod and verify `mk_dhcp_host` accepts `client_id`
- [ ] Confirm hermes renews to `2601:441:8483:b503::13` after reservation + lease delete


Made with [Cursor](https://cursor.com)