### PR TITLE
feat(deploy): hub.freeblizz.com registry with pinned tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,7 @@ stages:
   - scanning
   - test
   - security
+  - build
   - deploy
 
 variables:
@@ -306,6 +307,63 @@ trivy_fs_scan:
     paths:
       - trivy-fs-report.json
   allow_failure: false
+
+build:image:
+  stage: build
+  timeout: 30m
+  image:
+    name: gcr.io/kaniko-project/executor:debug
+    entrypoint: [""]
+  variables:
+    OPNSENSE_MCP_IMAGE: hub.freeblizz.com/opnsense-mcp
+  before_script:
+    - mkdir -p /kaniko/.docker
+    - |
+      if [ -z "${HUB_FREEBLIZZ_USER:-}" ] || [ -z "${HUB_FREEBLIZZ_PASSWORD:-}" ]; then
+        echo "ERROR: HUB_FREEBLIZZ_USER and HUB_FREEBLIZZ_PASSWORD are required for registry push."
+        exit 1
+      fi
+    - |
+      echo "{\"auths\":{\"hub.freeblizz.com\":{\"auth\":\"$(echo -n "${HUB_FREEBLIZZ_USER}:${HUB_FREEBLIZZ_PASSWORD}" | base64 -w 0)\"}}}" > /kaniko/.docker/config.json
+  script:
+    - /kaniko/executor
+      --context "${CI_PROJECT_DIR}"
+      --dockerfile deploy/Containerfile
+      --build-arg "GIT_COMMIT=${CI_COMMIT_SHORT_SHA}"
+      --build-arg "GIT_REF=${CI_COMMIT_REF_NAME}"
+      --build-arg "BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      --destination "${OPNSENSE_MCP_IMAGE}:${CI_COMMIT_SHORT_SHA}"
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+    - if: '$CI_COMMIT_TAG'
+
+.deploy_ssh:
+  before_script:
+    - apk add --no-cache openssh-client bash
+    - bash deploy/ci/ssh-setup.sh
+
+deploy:strongpod:
+  stage: deploy
+  timeout: 20m
+  image: alpine:3.22.0
+  extends: .deploy_ssh
+  variables:
+    OPNSENSE_MCP_IMAGE_REPO: hub.freeblizz.com/opnsense-mcp
+    OPNSENSE_MCP_IMAGE_TAG: $CI_COMMIT_SHORT_SHA
+  script:
+    - scp deploy/ci/deploy-strongpod.sh "${OPNSENSE_MCP_DEPLOY_USER:-root}@${OPNSENSE_MCP_DEPLOY_HOST}:/tmp/opnsense-mcp-deploy.sh"
+    - |
+      ssh -o StrictHostKeyChecking=no "${OPNSENSE_MCP_DEPLOY_USER:-root}@${OPNSENSE_MCP_DEPLOY_HOST}" \
+        "sudo env OPNSENSE_MCP_IMAGE_REPO=${OPNSENSE_MCP_IMAGE_REPO} OPNSENSE_MCP_IMAGE_TAG=${CI_COMMIT_SHORT_SHA} bash /tmp/opnsense-mcp-deploy.sh"
+  needs:
+    - job: build:image
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      when: manual
+      allow_failure: false
+  environment:
+    name: strongpod
+    url: https://opnsense-mcp.freeblizz.com/mcp
 
 # Aggregate security artifacts for download from the pipeline (not GitLab Pages).
 collect_reports:

--- a/deploy/Containerfile
+++ b/deploy/Containerfile
@@ -1,5 +1,5 @@
 # Build from repository root:
-#   podman build -f deploy/Containerfile -t localhost/opnsense-mcp:test .
+#   podman build -f deploy/Containerfile -t hub.freeblizz.com/opnsense-mcp:<tag> .
 # The MCP listener is HTTP only. Terminate TLS on the host (see deploy/TLS.md + Caddy examples).
 # Clients connect to /mcp path (Streamable HTTP, MCP spec 2025-03-26).
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,35 +1,50 @@
 # Deploying OPNsense MCP (Streamable HTTP Mode)
 
-This folder is for the centralized `Streamable HTTP` deployment path.
+Centralized Podman quadlet deployment with **Caddy** TLS and a pinned image from **`hub.freeblizz.com`**.
 
 For local IDE usage (`STDIO`), use the root quickstart instead:
 [`../docs/GETTING_STARTED.md`](../docs/GETTING_STARTED.md).
 
-## Fast Path
+## Fast path
 
 Canonical reference:
 [`../docs/CENTRALIZED_DEPLOY_SPEC.md`](../docs/CENTRALIZED_DEPLOY_SPEC.md)
 
-Install on Linux as root:
+On the host (as root):
 
 ```bash
-sudo bash deploy/install.sh
+podman login hub.freeblizz.com   # if required
+sudo OPNSENSE_MCP_IMAGE_TAG=<git-short-sha> bash deploy/install.sh
 ```
+
+GitLab CI on `main` builds and pushes `hub.freeblizz.com/opnsense-mcp:$CI_COMMIT_SHORT_SHA`.
+Use the manual **deploy:strongpod** job or re-run install with that tag.
 
 After TLS and DNS are in place, clients connect to:
 
 ```text
-https://<your-hostname>/mcp
+https://opnsense-mcp.freeblizz.com/mcp
 ```
 
-## Runtime Summary
+## Image modes
+
+| Mode | Command |
+|------|---------|
+| Pull from registry (default) | `sudo OPNSENSE_MCP_IMAGE_TAG=82646d9 bash deploy/install.sh` |
+| Refresh quadlets only | `sudo OPNSENSE_MCP_IMAGE_TAG=82646d9 bash deploy/install.sh --skip-image` |
+| Local dev build | `sudo OPNSENSE_MCP_IMAGE_TAG=dev-test bash deploy/install.sh --build-local` |
+| Build and push to registry | `sudo OPNSENSE_MCP_IMAGE_TAG=1.0.0 bash deploy/install.sh --build-push` |
+
+`:latest` is rejected. Tags must be a git short SHA from CI or an explicit semver.
+
+## Runtime summary
 
 - App container runs FastMCP natively (`python3 main.py --transport streamable-http --host 0.0.0.0 --port 8765`).
-- App listens on HTTP `8765` inside the pod/network; MCP endpoint is `/mcp` (Streamable HTTP, MCP spec 2025-03-26).
+- App listens on HTTP `8765` inside the pod/network; MCP endpoint is `/mcp`.
 - TLS is terminated by Caddy (`deploy/TLS.md`).
 
-## Required Follow-ups
+## Required follow-ups
 
 - Configure secrets in `environment` (see `environment.example`).
 - Configure certs and hostname in [`TLS.md`](TLS.md).
-- Adjust quadlet variables only if defaults do not match your host network.
+- Set `OPNSENSE_MCP_IMAGE_TAG` to a tag that exists in `hub.freeblizz.com`.

--- a/deploy/ci/deploy-strongpod.sh
+++ b/deploy/ci/deploy-strongpod.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Roll out a pinned image tag on the deploy host (called from GitLab CI).
+set -euo pipefail
+
+IMAGE_REPO="${OPNSENSE_MCP_IMAGE_REPO:-hub.freeblizz.com/opnsense-mcp}"
+IMAGE_TAG="${OPNSENSE_MCP_IMAGE_TAG:-${CI_COMMIT_SHORT_SHA:-}}"
+QUADLET_APP="/etc/containers/systemd/opnsense-mcp-app.container"
+INSTALL_ROOT="${OPNSENSE_MCP_INSTALL_ROOT:-/opt/containerdata/opnsense-mcp}"
+
+if [[ -z "${IMAGE_TAG}" ]]; then
+  echo "error: OPNSENSE_MCP_IMAGE_TAG or CI_COMMIT_SHORT_SHA is required" >&2
+  exit 1
+fi
+
+if [[ "${IMAGE_TAG}" == "latest" ]]; then
+  echo "error: deploy tag must be pinned (not latest)" >&2
+  exit 1
+fi
+
+if [[ ! -f "${QUADLET_APP}" ]]; then
+  echo "error: ${QUADLET_APP} not found — run install.sh on the host first" >&2
+  exit 1
+fi
+
+sed -i "s|^Image=.*|Image=${IMAGE_REPO}:${IMAGE_TAG}|" "${QUADLET_APP}"
+sed -i "s|hub.freeblizz.com/opnsense-mcp:.*|${IMAGE_REPO}:${IMAGE_TAG}|" "${QUADLET_APP}"
+sed -i "s|localhost/opnsense-mcp:.*|${IMAGE_REPO}:${IMAGE_TAG}|" "${QUADLET_APP}"
+
+if [[ -f "${INSTALL_ROOT}/environment" ]]; then
+  grep -v '^OPNSENSE_MCP_IMAGE_TAG=' "${INSTALL_ROOT}/environment" >"${INSTALL_ROOT}/environment.tmp" || true
+  printf 'OPNSENSE_MCP_IMAGE_TAG=%s\n' "${IMAGE_TAG}" >>"${INSTALL_ROOT}/environment.tmp"
+  mv "${INSTALL_ROOT}/environment.tmp" "${INSTALL_ROOT}/environment"
+  chmod 600 "${INSTALL_ROOT}/environment"
+fi
+
+podman pull "${IMAGE_REPO}:${IMAGE_TAG}"
+systemctl daemon-reload
+systemctl restart opnsense-mcp-app.service opnsense-mcp-caddy.service || systemctl restart opnsense-mcp-app.service
+
+podman ps --filter name=opnsense-mcp-app --format '{{.Image}}'

--- a/deploy/ci/ssh-setup.sh
+++ b/deploy/ci/ssh-setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Configure SSH for opnsense-mcp deploy jobs.
+set -euo pipefail
+
+if [[ -z "${OPNSENSE_MCP_DEPLOY_SSH_KEY_B64:-}" && -z "${OPNSENSE_MCP_DEPLOY_SSH_KEY:-}" ]]; then
+  echo "error: OPNSENSE_MCP_DEPLOY_SSH_KEY_B64 or OPNSENSE_MCP_DEPLOY_SSH_KEY is required" >&2
+  exit 1
+fi
+
+if [[ -z "${OPNSENSE_MCP_DEPLOY_HOST:-}" ]]; then
+  echo "error: OPNSENSE_MCP_DEPLOY_HOST is not set" >&2
+  exit 1
+fi
+
+install -d -m 700 ~/.ssh
+if [[ -n "${OPNSENSE_MCP_DEPLOY_SSH_KEY_B64:-}" ]]; then
+  printf '%s' "${OPNSENSE_MCP_DEPLOY_SSH_KEY_B64}" | base64 -d >~/.ssh/id_ed25519
+elif [[ -f "${OPNSENSE_MCP_DEPLOY_SSH_KEY}" ]]; then
+  install -m 600 "${OPNSENSE_MCP_DEPLOY_SSH_KEY}" ~/.ssh/id_ed25519
+else
+  printf '%s\n' "${OPNSENSE_MCP_DEPLOY_SSH_KEY}" >~/.ssh/id_ed25519
+fi
+chmod 600 ~/.ssh/id_ed25519
+if ! ssh-keygen -y -f ~/.ssh/id_ed25519 >/dev/null 2>&1; then
+  echo "error: deploy SSH private key is invalid after setup" >&2
+  exit 1
+fi
+ssh-keyscan -H "${OPNSENSE_MCP_DEPLOY_HOST}" >>~/.ssh/known_hosts 2>/dev/null || true

--- a/deploy/environment.example
+++ b/deploy/environment.example
@@ -6,6 +6,11 @@
 
 OPNSENSE_MCP_INSTALL_ROOT=/opt/containerdata/opnsense-mcp
 
+# Pinned container images (installer writes these; do not use :latest).
+OPNSENSE_MCP_IMAGE_REPO=hub.freeblizz.com/opnsense-mcp
+OPNSENSE_MCP_IMAGE_TAG=
+OPNSENSE_MCP_CADDY_IMAGE=docker.io/library/caddy:2.9.1-alpine
+
 OPNSENSE_FIREWALL_HOST=firewall.example.com
 OPNSENSE_API_KEY=
 OPNSENSE_API_SECRET=

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,34 +1,46 @@
 #!/usr/bin/env bash
-# OPNsense MCP centralized install (Linux amd64). GitLab is the default clone source.
-# Idempotent: safe to re-run (git pull, rebuild, systemd reload).
+# OPNsense MCP centralized install (Linux amd64). Pulls a pinned image from hub.freeblizz.com.
+# Idempotent: safe to re-run (refresh quadlets, pull image, systemd reload).
 #
-#   curl -fsSL 'https://gitlab.freeblizz.com/coreyhines/opensense-mcp/-/raw/main/deploy/install.sh' | sudo bash
-# Optional: clone a different ref (fork, release branch, etc.):
-#   sudo env OPNSENSE_MCP_GIT_REF=my-branch bash deploy/install.sh
-# Override clone URL:
-#   sudo OPNSENSE_MCP_REPO_URL='https://gitlab.../opensense-mcp.git' bash deploy/install.sh
+#   sudo OPNSENSE_MCP_IMAGE_TAG=<git-short-sha> bash deploy/install.sh
+#
+# One-liner (set tag from latest main CI build):
+#   curl -fsSL 'https://gitlab.freeblizz.com/coreyhines/opensense-mcp/-/raw/main/deploy/install.sh' | \
+#     sudo env OPNSENSE_MCP_IMAGE_TAG=82646d9 bash
+#
+# Local dev build (does not push):
+#   sudo OPNSENSE_MCP_IMAGE_TAG=dev-$(git rev-parse --short HEAD) bash deploy/install.sh --build-local
 #
 set -euo pipefail
 
 readonly DEFAULT_REPO_URL="${OPNSENSE_MCP_REPO_URL:-https://gitlab.freeblizz.com/coreyhines/opensense-mcp.git}"
-# Default git ref is main (see docs/CENTRALIZED_DEPLOY_SPEC.md); override with OPNSENSE_MCP_GIT_REF.
 readonly GIT_REF="${OPNSENSE_MCP_GIT_REF:-main}"
-# Default matches strongpod-style layout under /opt/containerdata (override with OPNSENSE_MCP_INSTALL_ROOT).
 readonly INSTALL_ROOT="${OPNSENSE_MCP_INSTALL_ROOT:-/opt/containerdata/opnsense-mcp}"
 readonly SRC_DIR="${INSTALL_ROOT}/src"
 readonly CADDYFILE_HOST="${INSTALL_ROOT}/Caddyfile"
-readonly IMAGE_REPO="${OPNSENSE_MCP_IMAGE_REPO:-localhost/opnsense-mcp}"
-readonly IMAGE_TAG="${OPNSENSE_MCP_IMAGE_TAG:-latest}"
+readonly DEFAULT_IMAGE_REPO="hub.freeblizz.com/opnsense-mcp"
+readonly DEFAULT_CADDY_IMAGE="docker.io/library/caddy:2.9.1-alpine"
+
+IMAGE_REPO="${OPNSENSE_MCP_IMAGE_REPO:-${DEFAULT_IMAGE_REPO}}"
+EXPLICIT_IMAGE_TAG="${OPNSENSE_MCP_IMAGE_TAG:-}"
+IMAGE_TAG="${EXPLICIT_IMAGE_TAG}"
+CADDY_IMAGE="${OPNSENSE_MCP_CADDY_IMAGE:-${DEFAULT_CADDY_IMAGE}}"
 RUNTIME="${OPNSENSE_MCP_RUNTIME:-podman}"
+SKIP_IMAGE=0
+BUILD_LOCAL=0
+BUILD_PUSH=0
 
 usage() {
-  echo "Usage: $0 [--runtime podman|docker]" >&2
-  echo "  Env: OPNSENSE_MCP_REPO_URL, OPNSENSE_MCP_GIT_REF, OPNSENSE_MCP_INSTALL_ROOT," >&2
-  echo "       OPNSENSE_MCP_IMAGE_REPO, OPNSENSE_MCP_IMAGE_TAG" >&2
-  echo "  Quadlet (Podman): OPNSENSE_MCP_POD_NAME, OPNSENSE_MCP_CONTAINER_NAME," >&2
+  echo "Usage: $0 [--runtime podman|docker] [--skip-image] [--build-local] [--build-push]" >&2
+  echo "  Default: pull hub.freeblizz.com/opnsense-mcp:\$OPNSENSE_MCP_IMAGE_TAG (pinned tag required)." >&2
+  echo "  Env: OPNSENSE_MCP_IMAGE_REPO (default ${DEFAULT_IMAGE_REPO})" >&2
+  echo "       OPNSENSE_MCP_IMAGE_TAG (required unless already in environment file)" >&2
+  echo "       OPNSENSE_MCP_CADDY_IMAGE (default ${DEFAULT_CADDY_IMAGE})" >&2
+  echo "       OPNSENSE_MCP_REPO_URL, OPNSENSE_MCP_GIT_REF, OPNSENSE_MCP_INSTALL_ROOT" >&2
+  echo "  Quadlet: OPNSENSE_MCP_POD_NAME, OPNSENSE_MCP_CONTAINER_NAME," >&2
   echo "    OPNSENSE_MCP_CADDY_CONTAINER_NAME, OPNSENSE_MCP_NETWORK, OPNSENSE_MCP_IP," >&2
-  echo "    OPNSENSE_MCP_IP6, OPNSENSE_MCP_DNS (space-separated), OPNSENSE_MCP_TLS_CERTS" >&2
-  echo "  Interactive prompts run only when stdin is a TTY (not when using curl|bash)." >&2
+  echo "    OPNSENSE_MCP_IP6, OPNSENSE_MCP_DNS, OPNSENSE_MCP_TLS_CERTS" >&2
+  echo "  Run 'podman login hub.freeblizz.com' before install if the registry requires auth." >&2
 }
 
 while [[ $# -gt 0 ]]; do
@@ -38,6 +50,9 @@ while [[ $# -gt 0 ]]; do
       if [[ -z "${RUNTIME}" ]]; then echo "--runtime needs a value" >&2; exit 1; fi
       shift 2
       ;;
+    --skip-image) SKIP_IMAGE=1; shift ;;
+    --build-local) BUILD_LOCAL=1; shift ;;
+    --build-push) BUILD_PUSH=1; shift ;;
     -h | --help)
       usage
       exit 0
@@ -56,14 +71,18 @@ if [[ "$(id -u)" -ne 0 ]]; then
   exit 1
 fi
 
-echo "opnsense-mcp install: INSTALL_ROOT=${INSTALL_ROOT} SRC_DIR=${SRC_DIR} GIT_REF=${GIT_REF} RUNTIME=${RUNTIME}" >&2
+if [[ "${BUILD_LOCAL}" -eq 1 && "${BUILD_PUSH}" -eq 1 ]]; then
+  echo "error: use only one of --build-local or --build-push" >&2
+  exit 1
+fi
+
+echo "opnsense-mcp install: INSTALL_ROOT=${INSTALL_ROOT} SRC_DIR=${SRC_DIR} GIT_REF=${GIT_REF} RUNTIME=${RUNTIME} IMAGE=${IMAGE_REPO}:${IMAGE_TAG:-<unset>}" >&2
 
 mkdir -p "${INSTALL_ROOT}" /etc/containers/systemd/opnsense-mcp
 
 if [[ ! -d "${SRC_DIR}/.git" ]]; then
   git clone --depth 1 --branch "${GIT_REF}" "${DEFAULT_REPO_URL}" "${SRC_DIR}"
 else
-  # Install-managed tree: always match remote (avoids diverged shallow clones breaking pull --ff-only).
   git -C "${SRC_DIR}" fetch origin "${GIT_REF}" --depth 1
   git -C "${SRC_DIR}" reset --hard "origin/${GIT_REF}"
 fi
@@ -91,11 +110,32 @@ verify_deploy_tree() {
 
 verify_deploy_tree
 
-# --- Quadlet: container names, optional Podman network/static IPs, TLS cert host path ---
+# shellcheck source=lib.sh
+source "${SRC_DIR}/deploy/lib.sh"
+normalize_image_repo
+
+collect_image_settings() {
+  local tty_device=/dev/tty
+
+  if [[ -z "${IMAGE_TAG}" && -f "${ENV_HOST_PATH}" ]]; then
+    load_environment_file "${ENV_HOST_PATH}"
+    IMAGE_TAG="${OPNSENSE_MCP_IMAGE_TAG:-}"
+    IMAGE_REPO="${OPNSENSE_MCP_IMAGE_REPO:-${IMAGE_REPO}}"
+    CADDY_IMAGE="${OPNSENSE_MCP_CADDY_IMAGE:-${CADDY_IMAGE}}"
+    normalize_image_repo
+  fi
+
+  if is_interactive_shell && [[ -z "${IMAGE_TAG}" ]]; then
+    read -r -p "Pinned image tag (git short SHA from CI, not 'latest'): " IMAGE_TAG <"${tty_device}" || true
+  fi
+
+  validate_pinned_image_tag "${IMAGE_TAG}"
+}
+
 collect_quadlet_settings() {
   local tty_device=/dev/tty
   local interactive=0
-  if [[ -t 0 ]] && [[ -e "${tty_device}" ]] && [[ -r "${tty_device}" ]]; then
+  if is_interactive_shell; then
     interactive=1
   fi
 
@@ -130,7 +170,6 @@ collect_quadlet_settings() {
   OPNSENSE_MCP_CONTAINER_NAME=${OPNSENSE_MCP_CONTAINER_NAME:-opnsense-mcp-app}
   OPNSENSE_MCP_CADDY_CONTAINER_NAME=${OPNSENSE_MCP_CADDY_CONTAINER_NAME:-opnsense-mcp-caddy}
   OPNSENSE_MCP_TLS_CERTS=${OPNSENSE_MCP_TLS_CERTS:-/opt/certs/wild}
-  # set -u: optional quadlet keys must be bound even when not in the shell env or install file.
   OPNSENSE_MCP_NETWORK=${OPNSENSE_MCP_NETWORK:-}
   OPNSENSE_MCP_IP=${OPNSENSE_MCP_IP:-}
   OPNSENSE_MCP_IP6=${OPNSENSE_MCP_IP6:-}
@@ -213,7 +252,7 @@ write_caddy_quadlet() {
     printf '%s\n' ''
     printf '%s\n' '[Container]'
     printf '%s\n' "Pod=${pod_quadlet_file}"
-    printf '%s\n' 'Image=docker.io/library/caddy:2-alpine'
+    printf '%s\n' "Image=${CADDY_IMAGE}"
     printf '%s\n' "ContainerName=${OPNSENSE_MCP_CADDY_CONTAINER_NAME}"
     printf '%s\n' "Volume=${OPNSENSE_MCP_TLS_CERTS}:/opt/certs/wild:ro,Z"
     printf '%s\n' "Volume=${CADDYFILE_HOST}:/etc/caddy/Caddyfile:ro,Z"
@@ -227,6 +266,32 @@ write_caddy_quadlet() {
     printf '%s\n' 'WantedBy=multi-user.target'
   } >"${out}"
   chmod 644 "${out}"
+}
+
+build_image() {
+  local version_full="${IMAGE_REPO}:${IMAGE_TAG}"
+  local build_git_commit
+  local build_time
+  build_git_commit="$(git -C "${SRC_DIR}" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)"
+  build_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "Building ${version_full} (git_commit=${build_git_commit} git_ref=${GIT_REF} build_time=${build_time})..." >&2
+  "${RUNTIME}" build -f "${SRC_DIR}/deploy/Containerfile" -t "${version_full}" \
+    --build-arg "GIT_COMMIT=${build_git_commit}" \
+    --build-arg "GIT_REF=${GIT_REF}" \
+    --build-arg "BUILD_TIME=${build_time}" \
+    "${SRC_DIR}"
+}
+
+push_image() {
+  local version_full="${IMAGE_REPO}:${IMAGE_TAG}"
+  echo "Pushing ${version_full}..." >&2
+  "${RUNTIME}" push "${version_full}"
+}
+
+pull_image() {
+  local version_full="${IMAGE_REPO}:${IMAGE_TAG}"
+  echo "Pulling ${version_full}..." >&2
+  "${RUNTIME}" pull "${version_full}"
 }
 
 ENV_HOST_PATH="${INSTALL_ROOT}/environment"
@@ -248,25 +313,17 @@ if [[ "$RUNTIME" == "podman" ]]; then
     echo "podman not found in PATH (install podman or use --runtime docker)." >&2
     exit 1
   fi
-  # Pick up OPNSENSE_MCP_* quadlet settings from the install env file (e.g. re-run or curl|bash without exporting).
   if [[ -f "${ENV_HOST_PATH}" ]]; then
-    set -a
-    # shellcheck disable=SC1090
-    . "${ENV_HOST_PATH}"
-    set +a
+    load_environment_file "${ENV_HOST_PATH}"
   fi
+  collect_image_settings
   collect_quadlet_settings
   POD_NAME="${OPNSENSE_MCP_POD_NAME}"
-  # Quadlet appends "-pod" to the .pod stem to form the unit name: opnsense-mcp.pod → opnsense-mcp-pod.service.
-  # So the file is always "opnsense-mcp.pod" (PodName= inside sets the Podman name independently).
   POD_QUADLET_FILE="opnsense-mcp.pod"
   POD_SVC="opnsense-mcp-pod.service"
-  # Top-level only: Podman before 4.7 does not recurse into subdirs under /etc/containers/systemd/ (podman#20236).
-  # Older installs used .../systemd/opnsense-mcp/ — remove those so 4.7+ never sees duplicate quadlets.
   readonly QUADLET_DIR=/etc/containers/systemd
   readonly LEGACY_QUADLET_SUBDIR=/etc/containers/systemd/opnsense-mcp
   mkdir -p "${QUADLET_DIR}"
-  # Quadlet basenames → systemd units (must match Caddy Requires=/After=).
   readonly MCP_QUADLET_BASENAME=opnsense-mcp-app
   readonly CADDY_QUADLET_BASENAME=opnsense-mcp-caddy
   MCP_APP_SVC="${MCP_QUADLET_BASENAME}.service"
@@ -281,29 +338,33 @@ if [[ "$RUNTIME" == "podman" ]]; then
   rmdir "${LEGACY_QUADLET_SUBDIR}" 2>/dev/null || true
   rm -f "${QUADLET_DIR}/opnsense-mcp.container" "${QUADLET_DIR}/caddy-opnsense-mcp.container" \
     "${QUADLET_DIR}/opnsense-mcp-pod.pod"
-  echo "Quadlet: dir=${QUADLET_DIR} file=${POD_QUADLET_FILE} PodName=${POD_NAME} systemd=${POD_SVC} MCP=${OPNSENSE_MCP_CONTAINER_NAME} Caddy=${OPNSENSE_MCP_CADDY_CONTAINER_NAME} Image=${IMAGE_REPO}:${IMAGE_TAG} Network=${OPNSENSE_MCP_NETWORK:-} IP=${OPNSENSE_MCP_IP:-} IP6=${OPNSENSE_MCP_IP6:-} DNS=${OPNSENSE_MCP_DNS:-} TLS=${OPNSENSE_MCP_TLS_CERTS}" >&2
+  echo "Quadlet: dir=${QUADLET_DIR} file=${POD_QUADLET_FILE} PodName=${POD_NAME} systemd=${POD_SVC} MCP=${OPNSENSE_MCP_CONTAINER_NAME} Caddy=${OPNSENSE_MCP_CADDY_CONTAINER_NAME} Image=${IMAGE_REPO}:${IMAGE_TAG} CaddyImage=${CADDY_IMAGE} Network=${OPNSENSE_MCP_NETWORK:-} IP=${OPNSENSE_MCP_IP:-} IP6=${OPNSENSE_MCP_IP6:-} DNS=${OPNSENSE_MCP_DNS:-} TLS=${OPNSENSE_MCP_TLS_CERTS}" >&2
   write_opnsense_mcp_pod "${QUADLET_DIR}/${POD_QUADLET_FILE}" "${POD_NAME}"
   write_opnsense_mcp_quadlet "${QUADLET_DIR}/${MCP_QUADLET_BASENAME}.container" "${POD_SVC}" "${POD_QUADLET_FILE}"
   write_caddy_quadlet "${QUADLET_DIR}/${CADDY_QUADLET_BASENAME}.container" "${POD_SVC}" "${MCP_APP_SVC}" "${POD_QUADLET_FILE}"
-  BUILD_GIT_COMMIT=$(
-    git -C "${SRC_DIR}" rev-parse --short=12 HEAD 2>/dev/null || echo unknown
-  )
-  BUILD_GIT_REF="${GIT_REF}"
-  BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  echo "Building image with git_commit=${BUILD_GIT_COMMIT} git_ref=${BUILD_GIT_REF} build_time=${BUILD_TIME}" >&2
-  "${RUNTIME}" build -f "${SRC_DIR}/deploy/Containerfile" -t "${IMAGE_REPO}:${IMAGE_TAG}" \
-    --build-arg "GIT_COMMIT=${BUILD_GIT_COMMIT}" \
-    --build-arg "GIT_REF=${BUILD_GIT_REF}" \
-    --build-arg "BUILD_TIME=${BUILD_TIME}" \
-    "${SRC_DIR}"
+
+  update_env_key "${ENV_HOST_PATH}" "OPNSENSE_MCP_IMAGE_REPO" "${IMAGE_REPO}"
+  update_env_key "${ENV_HOST_PATH}" "OPNSENSE_MCP_IMAGE_TAG" "${IMAGE_TAG}"
+  update_env_key "${ENV_HOST_PATH}" "OPNSENSE_MCP_CADDY_IMAGE" "${CADDY_IMAGE}"
+
+  if [[ "${SKIP_IMAGE}" -eq 1 ]]; then
+    echo "Skipping image pull/build (--skip-image)." >&2
+  elif [[ "${BUILD_PUSH}" -eq 1 ]]; then
+    build_image
+    push_image
+  elif [[ "${BUILD_LOCAL}" -eq 1 ]]; then
+    build_image
+  else
+    pull_image
+    "${RUNTIME}" pull "${CADDY_IMAGE}" || true
+  fi
+
   systemctl daemon-reload
   _pod_load_state=$(systemctl show -p LoadState --value "${POD_SVC}" 2>/dev/null || echo "unknown")
   if [[ "${_pod_load_state}" != "loaded" ]]; then
     echo "warning: ${POD_SVC} not loaded after daemon-reload (LoadState=${_pod_load_state})." >&2
     echo "  Install podman + quadlet support (often package podman-quadlet); check: podman --version (4.4+), journal for quadlet." >&2
   fi
-  # Quadlet: enabling the generated .service by name often fails ("transient or generated").
-  # Prefer enabling the .container unit files; fall back to start-only.
   enable_or_start_quadlet() {
     local cfile=$1
     local sname=$2

--- a/deploy/lib.sh
+++ b/deploy/lib.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Shared helpers for deploy/install.sh and deploy/uninstall.sh.
+set -euo pipefail
+
+readonly DEFAULT_IMAGE_REPO="hub.freeblizz.com/opnsense-mcp"
+readonly DEFAULT_CADDY_IMAGE="docker.io/library/caddy:2.9.1-alpine"
+
+is_interactive_shell() {
+  local tty_device=/dev/tty
+  if [[ -e "${tty_device}" && -r "${tty_device}" ]]; then
+    return 0
+  fi
+  if [[ -t 0 ]]; then
+    return 0
+  fi
+  return 1
+}
+
+parse_env_value() {
+  local value=$1
+  if [[ "${value}" =~ ^\'(.*)\'$ ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+  elif [[ "${value}" =~ ^\"(.*)\"$ ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+  else
+    printf '%s' "${value}"
+  fi
+}
+
+load_environment_file() {
+  local file=$1
+  local line key raw_value value
+
+  [[ -f "${file}" ]] || return 0
+
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    [[ "${line}" =~ ^[[:space:]]*# ]] && continue
+    [[ "${line}" =~ ^[[:space:]]*$ ]] && continue
+    [[ "${line}" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]] || continue
+    key="${BASH_REMATCH[1]}"
+    raw_value="${BASH_REMATCH[2]}"
+    value="$(parse_env_value "${raw_value}")"
+    printf -v "${key}" '%s' "${value}"
+    export "${key?}"
+  done <"${file}"
+}
+
+update_env_key() {
+  local file=$1 key=$2 value=$3
+  local tmp
+  tmp="$(mktemp)"
+  grep -v "^${key}=" "${file}" >"${tmp}" || true
+  printf '%s=%s\n' "${key}" "${value}" >>"${tmp}"
+  mv "${tmp}" "${file}"
+}
+
+validate_pinned_image_tag() {
+  local tag=$1
+  if [[ -z "${tag}" ]]; then
+    echo "error: OPNSENSE_MCP_IMAGE_TAG must be set to a pinned tag (not empty)." >&2
+    echo "  CI pushes hub.freeblizz.com/opnsense-mcp:<git-short-sha> on main." >&2
+    echo "  Example: sudo OPNSENSE_MCP_IMAGE_TAG=82646d9 bash deploy/install.sh" >&2
+    exit 1
+  fi
+  if [[ "${tag}" == "latest" ]]; then
+    echo "error: OPNSENSE_MCP_IMAGE_TAG must not be 'latest' (use a git SHA or semver tag)." >&2
+    exit 1
+  fi
+}
+
+normalize_image_repo() {
+  local repo="${IMAGE_REPO:-}"
+  repo="${repo#localhost/}"
+  if [[ -z "${repo}" ]]; then
+    IMAGE_REPO="${DEFAULT_IMAGE_REPO}"
+    return 0
+  fi
+  if [[ "${repo}" == opnsense-mcp ]]; then
+    IMAGE_REPO="${DEFAULT_IMAGE_REPO}"
+    return 0
+  fi
+  IMAGE_REPO="${repo}"
+}

--- a/deploy/opnsense-mcp-app.container.example
+++ b/deploy/opnsense-mcp-app.container.example
@@ -10,7 +10,7 @@ Requires=opnsense-mcp-pod.service
 
 [Container]
 Pod=opnsense-mcp.pod
-Image=localhost/opnsense-mcp:latest
+Image=hub.freeblizz.com/opnsense-mcp:<tag>
 ContainerName=opnsense-mcp-app
 Environment=OPNSENSE_MCP_INSTALL_ROOT=/opt/containerdata/opnsense-mcp
 

--- a/deploy/opnsense-mcp-caddy.container.example
+++ b/deploy/opnsense-mcp-caddy.container.example
@@ -11,7 +11,7 @@ Requires=opnsense-mcp-app.service
 
 [Container]
 Pod=opnsense-mcp.pod
-Image=docker.io/library/caddy:2-alpine
+Image=docker.io/library/caddy:2.9.1-alpine
 ContainerName=opnsense-mcp-caddy
 
 Volume=/opt/certs/wild:/opt/certs/wild:ro,Z

--- a/deploy/uninstall.sh
+++ b/deploy/uninstall.sh
@@ -54,6 +54,7 @@ if [[ "$RUNTIME" == "podman" ]]; then
   rmdir "${LEGACY_QUADLET_SUBDIR}" 2>/dev/null || true
   systemctl daemon-reload
   podman rmi localhost/opnsense-mcp:latest 2>/dev/null || true
+  podman rmi hub.freeblizz.com/opnsense-mcp:latest 2>/dev/null || true
 elif [[ "$RUNTIME" == "docker" ]]; then
   if [[ -d "${SRC_DIR}/deploy" ]]; then
     (cd "${SRC_DIR}" && docker compose -p opnsense-mcp -f deploy/docker-compose.yml down --rmi local 2>/dev/null) || true

--- a/docs/CENTRALIZED_DEPLOY_SPEC.md
+++ b/docs/CENTRALIZED_DEPLOY_SPEC.md
@@ -9,7 +9,8 @@ Single planning/implementation reference for the **network service** path. **IDE
 - **One MCP core** (same tools, same Python package) for stdio and centralized use.
 - **Centralized:** long-lived service, **Linux amd64** only for now (no macOS/ARM in scope).
 - **Installer:** **`curl | bash`** loading the script from **raw on `main`** (treat merges as production).
-- **Source / build:** **GitLab is primary** for clone or archive URLs; **build the image on the host** from this repo’s `deploy/Containerfile` (no registry pull required for v1).
+- **Source:** **GitLab** for clone URLs and CI image builds.
+- **Images:** **GitLab CI (Kaniko)** pushes **`hub.freeblizz.com/opnsense-mcp:<git-short-sha>`** on `main`. Host install **pulls** a pinned tag (no `:latest`).
 - **Podman** is the blessed server path (**rootful**, **UID 1000** convention for volume ownership where it matters).
 - **Docker:** supported as a first-class alternative; **do not** force Podman on Docker users.
 - **TLS:** **Caddy** in front; **TLS by default**; works with **real CA PEMs** or **self-signed** (paths to `fullchain` + `privkey` — client trust is the operator’s problem for self-signed).
@@ -45,19 +46,21 @@ Single planning/implementation reference for the **network service** path. **IDE
 - **Scripts:** `deploy/install.sh`, `deploy/uninstall.sh` (run as **root**).
 - **Default clone URL (GitLab):** `https://gitlab.freeblizz.com/coreyhines/opensense-mcp.git` — override with **`OPNSENSE_MCP_REPO_URL`**.
 - **Default git ref:** **`main`** (override with **`OPNSENSE_MCP_GIT_REF`** for forks or release branches).
-- **Install root:** **`OPNSENSE_MCP_INSTALL_ROOT`** (default **`/opt/containerdata/opnsense-mcp`**); checkout lives at **`$INSTALL_ROOT/src`**.
-- **Image tag (Podman):** **`OPNSENSE_MCP_IMAGE_REPO`** (default **`localhost/opnsense-mcp`**) and **`OPNSENSE_MCP_IMAGE_TAG`** (default **`latest`**) control the `podman build` tag and the quadlet `Image=` line.
-- **Podman (default):** clones/updates repo, **`podman build`**, installs **`<PodName>.pod`** (default **`opnsense-mcp-pod.pod`** when **`OPNSENSE_MCP_POD_NAME`** is unset or **`opnsense-mcp-pod`**), **`opnsense-mcp-app.container`**, and **`opnsense-mcp-caddy.container`** **directly under** **`/etc/containers/systemd/`** (not in a subdirectory: Podman before **4.7** does not recurse, so nested paths never produce units). Creates **`$INSTALL_ROOT/environment`** and **`$INSTALL_ROOT/Caddyfile`** if missing, then **`systemctl enable`** on those paths (or **`start`** if the distro rejects `enable` on generated quadlet services — see Red Hat / Podman quadlet notes). Re-run install removes prior copies under **`/etc/containers/systemd/opnsense-mcp/`** to avoid duplicate quadlets on 4.7+.
+- **Install root:** **`OPNSENSE_MCP_INSTALL_ROOT`** (default **`/opt/containerdata/opnsense-mcp`**); checkout lives at **`$INSTALL_ROOT/src`** (config templates only; app runs from registry image).
+- **Image (Podman):** **`OPNSENSE_MCP_IMAGE_REPO`** (default **`hub.freeblizz.com/opnsense-mcp`**) and **`OPNSENSE_MCP_IMAGE_TAG`** (**required**, must not be **`latest`**). CI pushes **`:$CI_COMMIT_SHORT_SHA`** on `main`. Installer **pulls** by default; **`--build-local`** / **`--build-push`** for dev or manual releases.
+- **Caddy image:** **`OPNSENSE_MCP_CADDY_IMAGE`** (default **`docker.io/library/caddy:2.9.1-alpine`**).
+- **Podman (default):** clones/updates repo for deploy assets, **pulls** pinned image, installs quadlets under **`/etc/containers/systemd/`**, creates **`$INSTALL_ROOT/environment`** and **`$INSTALL_ROOT/Caddyfile`** if missing, then **`systemctl enable`** / **`start`**.
 - **Docker:** `deploy/install.sh --runtime docker` runs **`docker compose -p opnsense-mcp -f deploy/docker-compose.yml up -d --build`** from the checkout.
 - **One-liner (raw script on `main`):**
   ```bash
-  curl -fsSL 'https://gitlab.freeblizz.com/coreyhines/opensense-mcp/-/raw/main/deploy/install.sh' | sudo bash
+  curl -fsSL 'https://gitlab.freeblizz.com/coreyhines/opensense-mcp/-/raw/main/deploy/install.sh' | \
+    sudo env OPNSENSE_MCP_IMAGE_TAG=<git-short-sha> bash
   ```
 - **Uninstall:** `sudo bash deploy/uninstall.sh` (from checkout) or copy the script to the host. **Docker:** `--runtime docker`. Optional **`--purge-env`** removes **`$INSTALL_ROOT/environment`**.
 
 ### Manual uninstall (no script)
 
-- **Podman:** `systemctl disable --now opnsense-mcp-caddy.service opnsense-mcp-app.service opnsense-mcp-pod.service opnsense-mcp.service caddy-opnsense-mcp.service` (also **`opnsense-mcp-pod-pod.service`**, **`pod-opnsense-mcp.service`**, **`pod-opnsense-mcp-pod.service`** for legacy installs); remove **`opnsense-mcp.pod`**, **`opnsense-mcp-pod.pod`**, **`opnsense-mcp-app.container`**, **`opnsense-mcp-caddy.container`** from **`/etc/containers/systemd/`** and any copies under **`/etc/containers/systemd/opnsense-mcp/`**; `systemctl daemon-reload`; `podman rmi localhost/opnsense-mcp:latest` if desired.
+- **Podman:** `systemctl disable --now opnsense-mcp-caddy.service opnsense-mcp-app.service opnsense-mcp-pod.service opnsense-mcp.service caddy-opnsense-mcp.service` (also **`opnsense-mcp-pod-pod.service`**, **`pod-opnsense-mcp.service`**, **`pod-opnsense-mcp-pod.service`** for legacy installs); remove **`opnsense-mcp.pod`**, **`opnsense-mcp-pod.pod`**, **`opnsense-mcp-app.container`**, **`opnsense-mcp-caddy.container`** from **`/etc/containers/systemd/`** and any copies under **`/etc/containers/systemd/opnsense-mcp/`**; `systemctl daemon-reload`; remove local images if desired (`podman rmi hub.freeblizz.com/opnsense-mcp:<tag>`).
 - **Docker:** from the git checkout, `docker compose -p opnsense-mcp -f deploy/docker-compose.yml down --rmi local`.
 - Remove or edit **`/opt/containerdata/opnsense-mcp/environment`** (or **`$INSTALL_ROOT/environment`**), **`$INSTALL_ROOT/Caddyfile`**, and the clone under **`/opt/containerdata/opnsense-mcp/src`** (default) as needed.
 
@@ -75,14 +78,29 @@ Set via **environment** before running `install.sh`, add the same keys to **`$IN
 | `OPNSENSE_MCP_IP6` | Podman `IP6=` static IPv6 on the **pod** (optional). |
 | `OPNSENSE_MCP_DNS` | Space-separated resolvers → multiple `DNS=` lines on the **pod** (optional). |
 | `OPNSENSE_MCP_TLS_CERTS` | Host directory with PEMs, mounted at `/opt/certs/wild` in containers (default `/opt/certs/wild`). |
+| `OPNSENSE_MCP_IMAGE_REPO` | Registry image (default `hub.freeblizz.com/opnsense-mcp`). |
+| `OPNSENSE_MCP_IMAGE_TAG` | **Required** pinned tag (git short SHA from CI or semver). |
+| `OPNSENSE_MCP_CADDY_IMAGE` | Pinned Caddy image (default `docker.io/library/caddy:2.9.1-alpine`). |
 
 The installer does **not** set **`PublishPort`** on the pod (typical **macvlan** / static **`IP=`** setups expose **443** and **8765** on the pod’s address instead of mapping host ports). Both containers set **`Pod=<PodName>.pod`** (default **`opnsense-mcp-pod.pod`**). Add **`PublishPort=`** in the generated **`<PodName>.pod`** only if you use bridge/NAT and need host port forwarding.
 
 **Example (non-interactive):**
 
 ```bash
-sudo env OPNSENSE_MCP_NETWORK=net-10 OPNSENSE_MCP_IP=10.0.10.50 OPNSENSE_MCP_TLS_CERTS=/opt/certs/wild bash deploy/install.sh
+sudo env OPNSENSE_MCP_IMAGE_TAG=82646d9 \
+  OPNSENSE_MCP_NETWORK=net-10 OPNSENSE_MCP_IP=10.0.10.50 \
+  OPNSENSE_MCP_TLS_CERTS=/opt/certs/wild bash deploy/install.sh
 ```
+
+### GitLab CI (registry + deploy)
+
+| CI/CD variable | Purpose |
+|----------------|---------|
+| `HUB_FREEBLIZZ_USER` / `HUB_FREEBLIZZ_PASSWORD` | Kaniko push to `hub.freeblizz.com` |
+| `OPNSENSE_MCP_DEPLOY_HOST` | strongpod hostname/IP for `deploy:strongpod` |
+| `OPNSENSE_MCP_DEPLOY_SSH_KEY_B64` | Root SSH key (base64) for deploy job |
+
+`build:image` runs on **`main`** (and git tags). **`deploy:strongpod`** is **manual** on `main` after a successful build.
 
 ### Install troubleshooting (strongpod / quadlet)
 
@@ -116,8 +134,8 @@ sudo env OPNSENSE_MCP_NETWORK=net-10 OPNSENSE_MCP_IP=10.0.10.50 OPNSENSE_MCP_TLS
 
 ## Deferred / later
 
-- **CI push** to a container registry and **pull-only** install (optional; not v1).
 - **Option B** (native HTTP in-process) — out of scope unless revisited.
+- **Semver release tags** on git tags (CI already builds on `CI_COMMIT_TAG`).
 
 ---
 

--- a/tests/test_deploy_lib.py
+++ b/tests/test_deploy_lib.py
@@ -1,0 +1,46 @@
+"""Tests for deploy/lib.sh helpers."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LIB_SH = REPO_ROOT / "deploy" / "lib.sh"
+
+
+def _run_lib_snippet(snippet: str) -> subprocess.CompletedProcess[str]:
+    script = f'source "{LIB_SH}"\n{snippet}'
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_validate_pinned_image_tag_rejects_latest() -> None:
+    result = _run_lib_snippet('validate_pinned_image_tag "latest"')
+    assert result.returncode != 0
+    assert "latest" in result.stderr
+
+
+def test_validate_pinned_image_tag_rejects_empty() -> None:
+    result = _run_lib_snippet('validate_pinned_image_tag ""')
+    assert result.returncode != 0
+    assert "OPNSENSE_MCP_IMAGE_TAG" in result.stderr
+
+
+def test_validate_pinned_image_tag_accepts_sha() -> None:
+    result = _run_lib_snippet('validate_pinned_image_tag "82646d9"')
+    assert result.returncode == 0
+
+
+def test_normalize_image_repo_defaults_to_hub() -> None:
+    result = _run_lib_snippet(
+        'IMAGE_REPO="localhost/opnsense-mcp"\n'
+        "normalize_image_repo\n"
+        'printf "%s" "${IMAGE_REPO}"'
+    )
+    assert result.returncode == 0
+    assert result.stdout == "hub.freeblizz.com/opnsense-mcp"


### PR DESCRIPTION
## Summary
- Replace `localhost/opnsense-mcp:latest` host builds with pinned pulls from `hub.freeblizz.com/opnsense-mcp:<tag>`
- Add GitLab Kaniko `build:image` job on `main` and manual `deploy:strongpod` rollout job
- Refactor `deploy/install.sh` with `--skip-image`, `--build-local`, and `--build-push` modes; reject `:latest`
- Pin Caddy to `2.9.1-alpine`; add `deploy/lib.sh` helpers and deploy lib tests

## Test plan
- [x] `uv run pytest tests/test_deploy_lib.py`
- [x] `bash -n deploy/install.sh deploy/lib.sh deploy/ci/deploy-strongpod.sh`
- [ ] Merge → GitLab `build:image` pushes `hub.freeblizz.com/opnsense-mcp:$CI_COMMIT_SHORT_SHA`
- [ ] Run manual `deploy:strongpod` or host install with pinned tag
- [ ] Verify strongpod: `podman ps --filter name=opnsense-mcp` shows hub image, not `localhost:latest`

## Rollout notes
GitLab CI variables required: `HUB_FREEBLIZZ_USER`, `HUB_FREEBLIZZ_PASSWORD`, `OPNSENSE_MCP_DEPLOY_HOST`, `OPNSENSE_MCP_DEPLOY_SSH_KEY_B64`.

Bootstrap option on strongpod if CI is not ready: `sudo OPNSENSE_MCP_IMAGE_TAG=<sha> bash deploy/install.sh --build-push`

Made with [Cursor](https://cursor.com)