### PR TITLE
feat(deploy): semver registry tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -317,6 +317,10 @@ build:image:
   variables:
     OPNSENSE_MCP_IMAGE: hub.freeblizz.com/opnsense-mcp
   before_script:
+    - apk add --no-cache bash git
+    - chmod +x deploy/ci/compute-image-tag.sh
+    - export OPNSENSE_MCP_IMAGE_TAG="$(bash deploy/ci/compute-image-tag.sh)"
+    - echo "OPNSENSE_MCP_IMAGE_TAG=${OPNSENSE_MCP_IMAGE_TAG}" | tee image-tag.env
     - mkdir -p /kaniko/.docker
     - |
       if [ -z "${HUB_FREEBLIZZ_USER:-}" ] || [ -z "${HUB_FREEBLIZZ_PASSWORD:-}" ]; then
@@ -326,13 +330,17 @@ build:image:
     - |
       echo "{\"auths\":{\"hub.freeblizz.com\":{\"auth\":\"$(echo -n "${HUB_FREEBLIZZ_USER}:${HUB_FREEBLIZZ_PASSWORD}" | base64 -w 0)\"}}}" > /kaniko/.docker/config.json
   script:
+    - echo "Pushing ${OPNSENSE_MCP_IMAGE}:${OPNSENSE_MCP_IMAGE_TAG}"
     - /kaniko/executor
       --context "${CI_PROJECT_DIR}"
       --dockerfile deploy/Containerfile
       --build-arg "GIT_COMMIT=${CI_COMMIT_SHORT_SHA}"
       --build-arg "GIT_REF=${CI_COMMIT_REF_NAME}"
       --build-arg "BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-      --destination "${OPNSENSE_MCP_IMAGE}:${CI_COMMIT_SHORT_SHA}"
+      --destination "${OPNSENSE_MCP_IMAGE}:${OPNSENSE_MCP_IMAGE_TAG}"
+  artifacts:
+    reports:
+      dotenv: image-tag.env
   rules:
     - if: '$CI_COMMIT_BRANCH == "main"'
     - if: '$CI_COMMIT_TAG'
@@ -349,16 +357,19 @@ deploy:strongpod:
   extends: .deploy_ssh
   variables:
     OPNSENSE_MCP_IMAGE_REPO: hub.freeblizz.com/opnsense-mcp
-    OPNSENSE_MCP_IMAGE_TAG: $CI_COMMIT_SHORT_SHA
   script:
     - scp deploy/ci/deploy-strongpod.sh "${OPNSENSE_MCP_DEPLOY_USER:-root}@${OPNSENSE_MCP_DEPLOY_HOST}:/tmp/opnsense-mcp-deploy.sh"
     - |
       ssh -o StrictHostKeyChecking=no "${OPNSENSE_MCP_DEPLOY_USER:-root}@${OPNSENSE_MCP_DEPLOY_HOST}" \
-        "sudo env OPNSENSE_MCP_IMAGE_REPO=${OPNSENSE_MCP_IMAGE_REPO} OPNSENSE_MCP_IMAGE_TAG=${CI_COMMIT_SHORT_SHA} bash /tmp/opnsense-mcp-deploy.sh"
+        "sudo env OPNSENSE_MCP_IMAGE_REPO=${OPNSENSE_MCP_IMAGE_REPO} OPNSENSE_MCP_IMAGE_TAG=${OPNSENSE_MCP_IMAGE_TAG} bash /tmp/opnsense-mcp-deploy.sh"
   needs:
     - job: build:image
+      artifacts: true
   rules:
     - if: '$CI_COMMIT_BRANCH == "main"'
+      when: manual
+      allow_failure: false
+    - if: '$CI_COMMIT_TAG'
       when: manual
       allow_failure: false
   environment:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -13,11 +13,11 @@ Canonical reference:
 On the host (as root):
 
 ```bash
-sudo OPNSENSE_MCP_IMAGE_TAG=<git-short-sha> bash deploy/install.sh
+sudo OPNSENSE_MCP_IMAGE_TAG=1.0.0 bash deploy/install.sh
 ```
 
-GitLab CI on `main` builds and pushes `hub.freeblizz.com/opnsense-mcp:$CI_COMMIT_SHORT_SHA`.
-Use the manual **deploy:strongpod** job or re-run install with that tag.
+GitLab CI on `main` pushes `hub.freeblizz.com/opnsense-mcp:<version>-dev.<sha>` (version from `pyproject.toml`).
+Git tag `v1.0.0` publishes `hub.freeblizz.com/opnsense-mcp:1.0.0`.
 
 After TLS and DNS are in place, clients connect to:
 
@@ -29,8 +29,8 @@ https://opnsense-mcp.freeblizz.com/mcp
 
 | Mode | Command |
 |------|---------|
-| Pull from registry (default) | `sudo OPNSENSE_MCP_IMAGE_TAG=82646d9 bash deploy/install.sh` |
-| Refresh quadlets only | `sudo OPNSENSE_MCP_IMAGE_TAG=82646d9 bash deploy/install.sh --skip-image` |
+| Pull from registry (default) | `sudo bash deploy/install.sh` (auto tag) or `sudo OPNSENSE_MCP_IMAGE_TAG=1.0.0 bash deploy/install.sh` |
+| Refresh quadlets only | `sudo OPNSENSE_MCP_IMAGE_TAG=1.0.0 bash deploy/install.sh --skip-image` |
 | Local dev build | `sudo OPNSENSE_MCP_IMAGE_TAG=dev-test bash deploy/install.sh --build-local` |
 | Build and push to registry | `sudo OPNSENSE_MCP_IMAGE_TAG=1.0.0 bash deploy/install.sh --build-push` |
 

--- a/deploy/ci/compute-image-tag.sh
+++ b/deploy/ci/compute-image-tag.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Print the hub.freeblizz.com image tag for the current tree or GitLab CI context.
+#
+# Release (git tag v1.2.3):     1.2.3
+# Main / branch (pyproject 1.2.3): 1.2.3-dev.<short-sha>
+#
+# Usage:
+#   ./deploy/ci/compute-image-tag.sh
+#   IMAGE_TAG=$(./deploy/ci/compute-image-tag.sh)
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+pyproject="${repo_root}/pyproject.toml"
+
+if [[ ! -f "${pyproject}" ]]; then
+  echo "error: pyproject.toml not found at ${pyproject}" >&2
+  exit 1
+fi
+
+pyproject_version="$(
+  sed -n 's/^version = "\([^"]*\)"/\1/p' "${pyproject}" | head -1
+)"
+if [[ -z "${pyproject_version}" ]]; then
+  echo "error: could not read version from pyproject.toml" >&2
+  exit 1
+fi
+
+if [[ -n "${CI_COMMIT_TAG:-}" ]]; then
+  printf '%s\n' "${CI_COMMIT_TAG#v}"
+  exit 0
+fi
+
+short_sha="${CI_COMMIT_SHORT_SHA:-}"
+if [[ -z "${short_sha}" ]]; then
+  short_sha="$(git -C "${repo_root}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+fi
+
+printf '%s\n' "${pyproject_version}-dev.${short_sha}"

--- a/deploy/environment.example
+++ b/deploy/environment.example
@@ -8,7 +8,8 @@ OPNSENSE_MCP_INSTALL_ROOT=/opt/containerdata/opnsense-mcp
 
 # Pinned container images (installer writes these; do not use :latest).
 OPNSENSE_MCP_IMAGE_REPO=hub.freeblizz.com/opnsense-mcp
-OPNSENSE_MCP_IMAGE_TAG=
+# Release: 1.0.0 (git tag v1.0.0). Main CI: 1.0.0-dev.<short-sha>
+OPNSENSE_MCP_IMAGE_TAG=1.0.0
 OPNSENSE_MCP_CADDY_IMAGE=docker.io/library/caddy:2.9.1-alpine
 
 OPNSENSE_FIREWALL_HOST=firewall.example.com

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -2,11 +2,10 @@
 # OPNsense MCP centralized install (Linux amd64). Pulls a pinned image from hub.freeblizz.com.
 # Idempotent: safe to re-run (refresh quadlets, pull image, systemd reload).
 #
-#   sudo OPNSENSE_MCP_IMAGE_TAG=<git-short-sha> bash deploy/install.sh
+#   sudo OPNSENSE_MCP_IMAGE_TAG=1.0.0 bash deploy/install.sh
 #
-# One-liner (set tag from latest main CI build):
-#   curl -fsSL 'https://gitlab.freeblizz.com/coreyhines/opensense-mcp/-/raw/main/deploy/install.sh' | \
-#     sudo env OPNSENSE_MCP_IMAGE_TAG=82646d9 bash
+# One-liner (auto tag from pyproject + git sha on main):
+#   curl -fsSL 'https://gitlab.freeblizz.com/coreyhines/opensense-mcp/-/raw/main/deploy/install.sh' | sudo bash
 #
 # Local dev build (does not push):
 #   sudo OPNSENSE_MCP_IMAGE_TAG=dev-$(git rev-parse --short HEAD) bash deploy/install.sh --build-local
@@ -122,8 +121,22 @@ collect_image_settings() {
     normalize_image_repo
   fi
 
-  if is_interactive_shell && [[ -z "${IMAGE_TAG}" ]]; then
-    read -r -p "Pinned image tag (git short SHA from CI, not 'latest'): " IMAGE_TAG <"${tty_device}" || true
+  if [[ -z "${IMAGE_TAG}" && -f "${SRC_DIR}/pyproject.toml" ]]; then
+    IMAGE_TAG="$(default_image_tag_for_tree "${SRC_DIR}")"
+    echo "Auto-selected image tag: ${IMAGE_TAG}" >&2
+  fi
+
+  if is_interactive_shell && [[ -z "${EXPLICIT_IMAGE_TAG}" ]]; then
+    local suggested="${IMAGE_TAG:-}"
+    if [[ -z "${suggested}" && -f "${SRC_DIR}/pyproject.toml" ]]; then
+      suggested="$(default_image_tag_for_tree "${SRC_DIR}")"
+    fi
+    read -r -p "Pinned image tag [${suggested}]: " _tag <"${tty_device}" || true
+    if [[ -n "${_tag}" ]]; then
+      IMAGE_TAG="${_tag}"
+    else
+      IMAGE_TAG="${suggested}"
+    fi
   fi
 
   validate_pinned_image_tag "${IMAGE_TAG}"

--- a/deploy/lib.sh
+++ b/deploy/lib.sh
@@ -58,14 +58,29 @@ validate_pinned_image_tag() {
   local tag=$1
   if [[ -z "${tag}" ]]; then
     echo "error: OPNSENSE_MCP_IMAGE_TAG must be set to a pinned tag (not empty)." >&2
-    echo "  CI pushes hub.freeblizz.com/opnsense-mcp:<git-short-sha> on main." >&2
-    echo "  Example: sudo OPNSENSE_MCP_IMAGE_TAG=82646d9 bash deploy/install.sh" >&2
+    echo "  Releases: hub.freeblizz.com/opnsense-mcp:<semver> (git tag vX.Y.Z)." >&2
+    echo "  Main builds: <semver>-dev.<short-sha> from deploy/ci/compute-image-tag.sh" >&2
+    echo "  Example: sudo OPNSENSE_MCP_IMAGE_TAG=1.0.0 bash deploy/install.sh" >&2
     exit 1
   fi
   if [[ "${tag}" == "latest" ]]; then
-    echo "error: OPNSENSE_MCP_IMAGE_TAG must not be 'latest' (use a git SHA or semver tag)." >&2
+    echo "error: OPNSENSE_MCP_IMAGE_TAG must not be 'latest' (use a semver release or -dev tag)." >&2
     exit 1
   fi
+  if [[ ! "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-dev\.[a-zA-Z0-9._-]+)?$ ]]; then
+    echo "error: OPNSENSE_MCP_IMAGE_TAG must be semver X.Y.Z or X.Y.Z-dev.<sha> (got: ${tag})." >&2
+    exit 1
+  fi
+}
+
+read_pyproject_version() {
+  local pyproject=$1
+  sed -n 's/^version = "\([^"]*\)"/\1/p' "${pyproject}" | head -1
+}
+
+default_image_tag_for_tree() {
+  local src_dir=$1
+  bash "${src_dir}/deploy/ci/compute-image-tag.sh"
 }
 
 normalize_image_repo() {

--- a/docs/CENTRALIZED_DEPLOY_SPEC.md
+++ b/docs/CENTRALIZED_DEPLOY_SPEC.md
@@ -10,7 +10,7 @@ Single planning/implementation reference for the **network service** path. **IDE
 - **Centralized:** long-lived service, **Linux amd64** only for now (no macOS/ARM in scope).
 - **Installer:** **`curl | bash`** loading the script from **raw on `main`** (treat merges as production).
 - **Source:** **GitLab** for clone URLs and CI image builds.
-- **Images:** **GitLab CI (Kaniko)** pushes **`hub.freeblizz.com/opnsense-mcp:<git-short-sha>`** on `main`. Host install **pulls** a pinned tag (no `:latest`).
+- **Images:** **GitLab CI (Kaniko)** pushes **`hub.freeblizz.com/opnsense-mcp:<semver>`** on git tag **`vX.Y.Z`**, or **`X.Y.Z-dev.<short-sha>`** on `main` (version from `pyproject.toml`). Host install **pulls** a pinned tag (no `:latest`).
 - **Podman** is the blessed server path (**rootful**, **UID 1000** convention for volume ownership where it matters).
 - **Docker:** supported as a first-class alternative; **do not** force Podman on Docker users.
 - **TLS:** **Caddy** in front; **TLS by default**; works with **real CA PEMs** or **self-signed** (paths to `fullchain` + `privkey` — client trust is the operator’s problem for self-signed).
@@ -47,15 +47,15 @@ Single planning/implementation reference for the **network service** path. **IDE
 - **Default clone URL (GitLab):** `https://gitlab.freeblizz.com/coreyhines/opensense-mcp.git` — override with **`OPNSENSE_MCP_REPO_URL`**.
 - **Default git ref:** **`main`** (override with **`OPNSENSE_MCP_GIT_REF`** for forks or release branches).
 - **Install root:** **`OPNSENSE_MCP_INSTALL_ROOT`** (default **`/opt/containerdata/opnsense-mcp`**); checkout lives at **`$INSTALL_ROOT/src`** (config templates only; app runs from registry image).
-- **Image (Podman):** **`OPNSENSE_MCP_IMAGE_REPO`** (default **`hub.freeblizz.com/opnsense-mcp`**) and **`OPNSENSE_MCP_IMAGE_TAG`** (**required**, must not be **`latest`**). CI pushes **`:$CI_COMMIT_SHORT_SHA`** on `main`. Installer **pulls** by default; **`--build-local`** / **`--build-push`** for dev or manual releases.
+- **Image (Podman):** **`OPNSENSE_MCP_IMAGE_REPO`** (default **`hub.freeblizz.com/opnsense-mcp`**) and **`OPNSENSE_MCP_IMAGE_TAG`** (**required**, semver **`X.Y.Z`** or **`X.Y.Z-dev.<sha>`**; not **`latest`**). Omit **`OPNSENSE_MCP_IMAGE_TAG`** to auto-select via **`deploy/ci/compute-image-tag.sh`**.
 - **Caddy image:** **`OPNSENSE_MCP_CADDY_IMAGE`** (default **`docker.io/library/caddy:2.9.1-alpine`**).
 - **Podman (default):** clones/updates repo for deploy assets, **pulls** pinned image, installs quadlets under **`/etc/containers/systemd/`**, creates **`$INSTALL_ROOT/environment`** and **`$INSTALL_ROOT/Caddyfile`** if missing, then **`systemctl enable`** / **`start`**.
 - **Docker:** `deploy/install.sh --runtime docker` runs **`docker compose -p opnsense-mcp -f deploy/docker-compose.yml up -d --build`** from the checkout.
 - **One-liner (raw script on `main`):**
   ```bash
-  curl -fsSL 'https://gitlab.freeblizz.com/coreyhines/opensense-mcp/-/raw/main/deploy/install.sh' | \
-    sudo env OPNSENSE_MCP_IMAGE_TAG=<git-short-sha> bash
+  curl -fsSL 'https://gitlab.freeblizz.com/coreyhines/opensense-mcp/-/raw/main/deploy/install.sh' | sudo bash
   ```
+  (Installer auto-selects `$(pyproject version)-dev.<short-sha>` when **`OPNSENSE_MCP_IMAGE_TAG`** is unset.)
 - **Uninstall:** `sudo bash deploy/uninstall.sh` (from checkout) or copy the script to the host. **Docker:** `--runtime docker`. Optional **`--purge-env`** removes **`$INSTALL_ROOT/environment`**.
 
 ### Manual uninstall (no script)
@@ -79,7 +79,15 @@ Set via **environment** before running `install.sh`, add the same keys to **`$IN
 | `OPNSENSE_MCP_DNS` | Space-separated resolvers → multiple `DNS=` lines on the **pod** (optional). |
 | `OPNSENSE_MCP_TLS_CERTS` | Host directory with PEMs, mounted at `/opt/certs/wild` in containers (default `/opt/certs/wild`). |
 | `OPNSENSE_MCP_IMAGE_REPO` | Registry image (default `hub.freeblizz.com/opnsense-mcp`). |
-| `OPNSENSE_MCP_IMAGE_TAG` | **Required** pinned tag (git short SHA from CI or semver). |
+| `OPNSENSE_MCP_IMAGE_TAG` | **Required** semver `X.Y.Z` (release) or `X.Y.Z-dev.<sha>` (main). Auto from `compute-image-tag.sh` if unset. |
+
+### Release workflow
+
+1. Bump **`version`** in **`pyproject.toml`** (e.g. `1.0.1`).
+2. Commit and push **`main`**.
+3. Tag and push: **`git tag v1.0.1 && git push origin v1.0.1`**
+4. GitLab **`build:image`** publishes **`hub.freeblizz.com/opnsense-mcp:1.0.1`**.
+5. Deploy: **`sudo OPNSENSE_MCP_IMAGE_TAG=1.0.1 bash deploy/install.sh`** or manual **`deploy:strongpod`**.
 | `OPNSENSE_MCP_CADDY_IMAGE` | Pinned Caddy image (default `docker.io/library/caddy:2.9.1-alpine`). |
 
 The installer does **not** set **`PublishPort`** on the pod (typical **macvlan** / static **`IP=`** setups expose **443** and **8765** on the pod’s address instead of mapping host ports). Both containers set **`Pod=<PodName>.pod`** (default **`opnsense-mcp-pod.pod`**). Add **`PublishPort=`** in the generated **`<PodName>.pod`** only if you use bridge/NAT and need host port forwarding.
@@ -87,7 +95,7 @@ The installer does **not** set **`PublishPort`** on the pod (typical **macvlan**
 **Example (non-interactive):**
 
 ```bash
-sudo env OPNSENSE_MCP_IMAGE_TAG=82646d9 \
+sudo env OPNSENSE_MCP_IMAGE_TAG=1.0.0 \
   OPNSENSE_MCP_NETWORK=net-10 OPNSENSE_MCP_IP=10.0.10.50 \
   OPNSENSE_MCP_TLS_CERTS=/opt/certs/wild bash deploy/install.sh
 ```
@@ -135,7 +143,6 @@ sudo env OPNSENSE_MCP_IMAGE_TAG=82646d9 \
 ## Deferred / later
 
 - **Option B** (native HTTP in-process) — out of scope unless revisited.
-- **Semver release tags** on git tags (CI already builds on `CI_COMMIT_TAG`).
 
 ---
 

--- a/tests/test_deploy_lib.py
+++ b/tests/test_deploy_lib.py
@@ -1,4 +1,4 @@
-"""Tests for deploy/lib.sh helpers."""
+"""Tests for deploy/lib.sh and deploy/ci/compute-image-tag.sh."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 LIB_SH = REPO_ROOT / "deploy" / "lib.sh"
+COMPUTE_TAG = REPO_ROOT / "deploy" / "ci" / "compute-image-tag.sh"
 
 
 def _run_lib_snippet(snippet: str) -> subprocess.CompletedProcess[str]:
@@ -31,8 +32,18 @@ def test_validate_pinned_image_tag_rejects_empty() -> None:
     assert "OPNSENSE_MCP_IMAGE_TAG" in result.stderr
 
 
-def test_validate_pinned_image_tag_accepts_sha() -> None:
-    result = _run_lib_snippet('validate_pinned_image_tag "82646d9"')
+def test_validate_pinned_image_tag_rejects_raw_sha() -> None:
+    result = _run_lib_snippet('validate_pinned_image_tag "6845616"')
+    assert result.returncode != 0
+
+
+def test_validate_pinned_image_tag_accepts_release() -> None:
+    result = _run_lib_snippet('validate_pinned_image_tag "1.0.0"')
+    assert result.returncode == 0
+
+
+def test_validate_pinned_image_tag_accepts_dev_build() -> None:
+    result = _run_lib_snippet('validate_pinned_image_tag "1.0.0-dev.6845616"')
     assert result.returncode == 0
 
 
@@ -44,3 +55,17 @@ def test_normalize_image_repo_defaults_to_hub() -> None:
     )
     assert result.returncode == 0
     assert result.stdout == "hub.freeblizz.com/opnsense-mcp"
+
+
+def test_compute_image_tag_uses_pyproject_dev_suffix() -> None:
+    result = subprocess.run(
+        ["bash", str(COMPUTE_TAG)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0
+    tag = result.stdout.strip()
+    assert tag.startswith("1.0.0-dev.")
+    assert len(tag.split(".")[-1]) >= 7


### PR DESCRIPTION
## Tag scheme

| When | Image tag | Example |
|------|-----------|---------|
| Git tag `v1.0.0` | `1.0.0` | Production release |
| `main` commit | `<pyproject-version>-dev.<sha>` | `1.0.0-dev.6845616` |

Version source: `pyproject.toml` (currently `1.0.0`).

## Release workflow

1. Bump `version` in `pyproject.toml`
2. `git tag v1.0.1 && git push origin v1.0.1`
3. CI publishes `hub.freeblizz.com/opnsense-mcp:1.0.1`
4. Deploy: `sudo OPNSENSE_MCP_IMAGE_TAG=1.0.1 bash deploy/install.sh`

## Test plan
- [x] `uv run pytest tests/test_deploy_lib.py`
- [ ] Tag `v1.0.0` on merge and redeploy strongpod with `1.0.0`

Made with [Cursor](https://cursor.com)